### PR TITLE
Gazelle sidebar design update

### DIFF
--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -21,7 +21,7 @@
           </div>
         </span>
       </div>
-        <p v-if="(cardOverflow && !expanded)" class="read-more"><el-button @click="expand" class="button">Read more...</el-button></p>
+        <p v-if="(cardOverflow && !expanded)" class="read-more"><el-button @click="expand" class="read-more-button">Read more...</el-button></p>
     </div>
   </div>
 </template>
@@ -213,7 +213,7 @@ export default {
   pointer-events: none;
 }
 
-.read-more .button{
+.read-more-button{
   width: 85px;
   height: 20px;
   font-family: Asap;
@@ -238,7 +238,9 @@ export default {
   font-style: normal;
   line-height: normal;
   letter-spacing: normal;
-  color: var(--vibrant-purple);
+  background-color: var(--vibrant-purple);
+  border: var(--vibrant-purple);
+  color: white;
   cursor: pointer;
 }
 

--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -176,8 +176,8 @@ export default {
 .seperator-path {
   width: 486px;
   height: 0px;
-  border: solid 1px var(--pale-grey);
-  background-color: var(--pale-grey);
+  border: solid 1px #e4e7ed;
+  background-color: #e4e7ed;
 }
 .title {
   padding-bottom: 5px;
@@ -229,7 +229,7 @@ export default {
   font-style: normal;
   line-height: normal;
   letter-spacing: normal;
-  color: var(--vibrant-purple);
+  color: #8300bf;
   padding: 0px;
   pointer-events: all;
   cursor: pointer;
@@ -244,8 +244,8 @@ export default {
   font-style: normal;
   line-height: normal;
   letter-spacing: normal;
-  background-color: var(--vibrant-purple);
-  border: var(--vibrant-purple);
+  background-color: #8300bf;
+  border: #8300bf;
   color: white;
   cursor: pointer;
   margin-top: 8px;

--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -3,23 +3,25 @@
     <div v-bind:class=" expanded ? 'dataset-card-expanded' : 'dataset-card'"  ref="card">
       <div v-if="entry.id !== 0" class="seperator-path"></div>
       <div class="card" >
-        <span class="card-left" >
+        <span class="card-left">
+          <img svg-inline class="banner-img" :src="thumbnail" @click="openDataset"/>
+          
+        </span>
+        <div class="card-right" >
           <div class="title" @click="cardClicked">{{entry.description}}</div>
           <div class="details">{{entry.contributors[0].name}}; {{entry.contributors[1].name}}</div>
           <div class="details">{{entry.numberSamples}} sample(s)</div>
-          <div class="details"><template v-for="(organ, i) in entry.organs"><template v-if="i !== 0">, </template>{{organ}}</template></div>
-          <div class="details"><template v-for="(sex, i) in entry.sexes"><template v-if="i !== 0">, </template>{{sex}}</template></div>
-          <div v-if="entry.ages" class="details"><template v-for="(sex, i) in entry.ages"><template v-if="i !== 0">, </template>{{sex}}</template></div>
-          <div class="details">Last updated: {{entry.updated}}</div>
-        </span>
-        <span class="card-right">
-          <img svg-inline class="banner-img" :src="thumbnail" @click="openDataset"/>
-          <div v-if="entry.scaffold || hasCSVFile">
-            <el-button @click="openDataset" size="mini" class="button" icon="el-icon-coin">Dataset</el-button>
-            <el-button v-if="entry.scaffold" @click="openScaffold" size="mini" class="button" icon="el-icon-view">Scaffold</el-button>
-            <el-button v-if="hasCSVFile"  @click="openPlot" size="mini" class="button" icon="el-icon-view">Plot</el-button>
+          <div>
+            <el-button @click="openDataset" size="mini" class="button" icon="el-icon-coin">View dataset</el-button>
           </div>
-        </span>
+          <div>
+            <el-button v-if="entry.scaffold" @click="openScaffold" size="mini" class="button" icon="el-icon-view">View scaffold</el-button>
+          </div>
+          <div>
+            <el-button v-if="hasCSVFile"  @click="openPlot" size="mini" class="button" icon="el-icon-view">View plot</el-button>
+          </div>
+        </div>
+        
       </div>
         <p v-if="(cardOverflow && !expanded)" class="read-more"><el-button @click="expand" class="read-more-button">Read more...</el-button></p>
     </div>
@@ -163,12 +165,6 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .dataset-card {
-  height: 230px;
-  padding-left: 16px;
-  position: relative;
-  overflow: hidden;
-}
-.dataset-card-expanded {
   padding-left: 16px;
   position: relative;
 }
@@ -179,7 +175,7 @@ export default {
   background-color: var(--pale-grey);
 }
 .title {
-  padding-bottom: 20px;
+  padding-bottom: 5px;
   font-family: Asap;
   font-size: 14px;
   font-weight: bold;
@@ -191,13 +187,18 @@ export default {
   cursor: pointer;
 }
 .card {
-  padding-top: 22px;
+  padding-top: 18px;
   position: relative;
   display: flex;
 }
 
 .card-left{
+  flex: 1
+}
+
+.card-right {
   flex: 1.3;
+  padding-left: 6px;
 }
 
 .dataset-card .read-more { 
@@ -242,12 +243,9 @@ export default {
   border: var(--vibrant-purple);
   color: white;
   cursor: pointer;
+  margin-top: 8px;
 }
 
-.card-right {
-  flex: 1;
-  padding-left: 6px;
-}
 .banner-img {
   width: 128px;
   height: 128px;

--- a/src/components/FloatingFlow.vue
+++ b/src/components/FloatingFlow.vue
@@ -87,7 +87,7 @@ export default {
         if (action.type == "Search") {
           // Line below filters by flatmap species (unused until more data is available)
           // this.$refs.sideBar.openSearch(action.label, [{facet: speciesMap[this.entries[0].resource], term:'species'}] )
-          this.$refs.sideBar.openSearch(action.label, [{facet: "All species", term:'species'}] )
+          this.$refs.sideBar.openSearch(action.label, [{facet: "All Species", term:'species'}] )
         } else {
           let newId = this.createNewEntry(action);
           this.bringDialogToFront(newId);

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -133,4 +133,6 @@ export default {
 </style>
 <style src="@/../assets/mapicon-species-style.css">
 </style>
+<style src="@/../assets/styleguide.css">
+</style>
 

--- a/src/components/MapIntegratedVuer.vue
+++ b/src/components/MapIntegratedVuer.vue
@@ -43,5 +43,3 @@ export default {
 }
 
 </style>
-<style src="@/../assets/styleguide.css">
-</style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -114,15 +114,15 @@ export default {
 }
 
 .el-menu--horizontal .el-menu-item:not(.is-disabled):hover{
-  color: var(--vibrant-purple);  
+  color: #8300bf;  
 }
 
 .el-submenu.is-opened >>> .el-submenu__title{
-  color: var(--vibrant-purple); 
+  color: #8300bf; 
 }
 
 .el-submenu__title:hover{
-  color: var(--vibrant-purple) !important; 
+  color: #8300bf !important; 
 }
 </style>
 <style scoped src='element-ui/lib/theme-chalk/menu.css'>

--- a/src/components/NavDropDownItem.vue
+++ b/src/components/NavDropDownItem.vue
@@ -46,7 +46,7 @@ export default {
   line-height: normal;
   letter-spacing: 1.05px;
   text-align: center;
-  color: var(--vibrant-purple);;
+  color: #8300bf;;
 }
 .description {
   width: 426px;
@@ -57,7 +57,7 @@ export default {
   font-style: normal;
   line-height: 130%;
   letter-spacing: 1.35px;
-  color: var(--brownish-grey);
+  color: #666666;
 }
 .image {
   width: 92px;

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -247,9 +247,9 @@ export default {
   text-align: right;
   color: rgb(48, 49, 51);
   font-family: Asap;
-  font-size: 17px;
+  font-size: 12.5px;
   font-weight: 500;
-  padding-top: 8px;
+  padding-top: 10px;
 }
 
 .search-filters {

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -223,6 +223,7 @@ export default {
 
 .cascader >>> .el-scrollbar__wrap{
   overflow-x: hidden;
+  margin-bottom: 2px !important;
 }
 
 .cascader >>> li[aria-owns*="cascader"] > .el-checkbox {

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -225,6 +225,10 @@ export default {
   overflow-x: hidden;
 }
 
+.cascader >>> li[aria-owns*="cascader"] > .el-checkbox {
+  display: none;
+}
+
 .dataset-results-feedback{
   text-align: left;
 }

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -221,6 +221,10 @@ export default {
   padding-bottom: 6px;
 }
 
+.cascader >>> .el-scrollbar__wrap{
+  overflow-x: hidden;
+}
+
 .dataset-results-feedback{
   text-align: left;
 }

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -295,16 +295,16 @@ export default {
 }
 
 .search-filters >>> .el-cascader-node.is-active{
-  color: var(--vibrant-purple);
+  color: #8300bf;
 }
 
 .search-filters >>> .el-cascader-node.in-active-path{
-  color: var(--vibrant-purple);
+  color: #8300bf;
 }
 
 .search-filters >>> .el-checkbox__input.is-checked > .el-checkbox__inner {
-  background-color: var(--vibrant-purple);
-  border-color: var(--vibrant-purple);
+  background-color: #8300bf;
+  border-color: #8300bf;
 }
 
 </style>

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -262,7 +262,20 @@ export default {
 .number-shown-select >>> .el-input__inner{
   width: 68px;
   height: 40px;
-  color: rgb(48, 49, 51)
+  color: rgb(48, 49, 51);
+}
+
+.search-filters >>> .el-cascader-node.is-active{
+  color: var(--vibrant-purple);
+}
+
+.search-filters >>> .el-cascader-node.in-active-path{
+  color: var(--vibrant-purple);
+}
+
+.search-filters >>> .el-checkbox__input.is-checked > .el-checkbox__inner {
+  background-color: var(--vibrant-purple);
+  border-color: var(--vibrant-purple);
 }
 
 </style>

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -25,7 +25,7 @@
       </el-select>
       <span
         class="dataset-results-feedback"
-      >{{this.numberOfDatasetsResultText}}</span>
+      >{{this.numberOfResultsText}}</span>
   </div>
 </template>
 
@@ -78,12 +78,8 @@ export default {
     };
   },
   computed: {
-    numberOfDatasetsResultText: function(){
-      var searchTermConfirmation = ''
-      if (this.entry.lastSearch !== ''){
-        searchTermConfirmation = `for '${this.entry.lastSearch}'`
-      }
-      return `${this.entry.numberOfHits} Datasets ${searchTermConfirmation} | Showing`
+    numberOfResultsText: function(){
+      return `${this.entry.numberOfHits} results | Showing`
     }
   },
   methods: {
@@ -247,9 +243,9 @@ export default {
   text-align: right;
   color: rgb(48, 49, 51);
   font-family: Asap;
-  font-size: 12.5px;
+  font-size: 18px;
   font-weight: 500;
-  padding-top: 10px;
+  padding-top: 8px;
 }
 
 .search-filters {
@@ -266,7 +262,7 @@ export default {
 .number-shown-select >>> .el-input__inner{
   width: 68px;
   height: 40px;
-  color: #8300bf;
+  color: rgb(48, 49, 51)
 }
 
 </style>

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -1,30 +1,31 @@
 <template>
   <div class="filters">
     <transition name="el-zoom-in-top">
-      <div v-show="showFilters" class="search-filters transition-box">
+      <span v-show="showFilters" class="search-filters transition-box">
           <el-cascader
           class="cascader"
           v-model="cascadeSelected"
-          placeholder="Filter"
+          placeholder=""
+          :collapse-tags="true"
           :options="options"
           :props="props"
           @change="cascadeEvent($event)"
           :show-all-levels="false"
           :append-to-body="false">
         </el-cascader>
-      </div>
+        <div v-if="cascadeSelected.length === 0" class="filter-default-value"> 
+          <img svg-inline class="filter-icon-inside" src='@/../assets/noun-filter.svg'/>
+          Apply Filters
+        </div>
+      </span>
     </transition>
-    <div class="filter-collapsed" @click="showFilters = !showFilters">
-      <img svg-inline class="filter-icon" src='@/../assets/noun-filter.svg'/>
-      Filter
-     </div>
-    
-    <span
-        class="dataset-results-feedback"
-      >{{this.numberOfDatasetsResultText}}</span>
+  
       <el-select class="number-shown-select"  v-model="numberShown" placeholder="10" @change="numberShownChanged($event)">
         <el-option v-for="item in numberDatasetsShown" :key="item" :label="item" :value="item"></el-option>
       </el-select>
+      <span
+        class="dataset-results-feedback"
+      >{{this.numberOfDatasetsResultText}}</span>
   </div>
 </template>
 
@@ -61,7 +62,7 @@ export default {
   },
   data: function () {
     return {
-      showFilters: false,
+      showFilters: true,
       cascadeSelected: [],
       numberShown: 10,
       filters: [],
@@ -194,11 +195,6 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.filters{
-    justify-content: center;
-    align-items: center;
-    padding-bottom: 10px;
-}
 
 .filter-icon{
   width: 12px;
@@ -206,6 +202,22 @@ export default {
   color: #292b66;
   transform: scale(2);
   bottom: -10px;
+}
+
+.filter-default-value{
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding-top: 10px;
+  padding-left: 16px;
+}
+
+.filter-icon-inside{
+  width: 12px;
+  height: 12px;
+  color: #292b66;
+  transform: scale(2);
 }
 
 .cascader {
@@ -231,56 +243,29 @@ export default {
 }
 
 .dataset-results-feedback{
-  text-align: left;
-}
-
-.filter-collapsed {
-  font-family: Asap;
-  font-size: 16px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
-  letter-spacing: normal;
-  color: #292b66;
-  width: 100px;
   float: right;
-  cursor: pointer;
-}
-
-.filter-select {
-  width: 120px;
-  height: 40px;
-  margin-right: 16px;
-  border-radius: 4px;
-  border: solid 1px #8300bf;
-  background-color: var(--white);
+  text-align: right;
+  color: rgb(48, 49, 51);
+  font-family: Asap;
+  font-size: 17px;
   font-weight: 500;
-  color: #8300bf;
-}
-
-.filters-row-2 {
-  padding-top: 16px;
-}
-
-.filter-select >>> .el-input__inner {
-  color: #8300bf;
-  padding-top: 0.25em;
-}
-
-.filter-select >>> .el-select-dropdown__item.selected {
-  color: #8300bf;
-  font-weight: normal;
-  font-family: Asap !important;
+  padding-top: 8px;
 }
 
 .search-filters {
-  text-align: left;
+  position: relative;
+  float:left;
+  padding-right: 15px;
+  padding-bottom: 12px;
+}
+
+.number-shown-select{
+  float: right;
 }
 
 .number-shown-select >>> .el-input__inner{
   width: 68px;
-  height: 32px;
+  height: 40px;
   color: #8300bf;
 }
 

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -34,12 +34,10 @@
           </div>
           <SearchFilters class="filters" ref="filtersRef" :entry="filterEntry" @filterResults="filterUpdate" @numberPerPage="numberPerPageUpdate"></SearchFilters>
           <div class="content scrollbar"  v-loading="loadingCards" ref="content">
-            <div class="card-container">
-              <span v-if="results.length === 0 && !loadingCards && !sciCrunchError" class="dataset-table-title">No results for <i>{{filterFacet}}, {{lastSearch}}</i></span>
-              <span v-if="sciCrunchError">{{sciCrunchError}}</span>
-              <span v-if="results.length > 0" class="dataset-table-title">Title</span>
-              <span v-if="results.length > 0" class="image-table-title">Image</span>
+            <div class="error-feedback" v-if="results.length === 0 && !loadingCards && !sciCrunchError">
+              No results found - Please change your search / filter criteria.
             </div>
+            <div class="error-feedback" v-if="sciCrunchError">{{sciCrunchError}}</div>
             <div v-for="o in results" :key="o.id" class="step-item">
               <DatasetCard :entry="o"></DatasetCard>
             </div>
@@ -442,6 +440,13 @@ export default {
   line-height: normal;
   letter-spacing: normal;
   color: #292b66;
+}
+
+.error-feedback{
+  font-family: Asap;
+  font-size: 14px;
+  font-style: italic;
+  padding-top: 15px;
 }
 
 .card-container {

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -343,7 +343,7 @@ export default {
   top: calc(50vh - 80px);
   right: 0px;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
-  border: solid 1px var(--pale-grey);
+  border: solid 1px #e4e7ed;
   background-color: #F7FAFF;
   text-align: center;
   vertical-align: middle;
@@ -373,7 +373,7 @@ export default {
   z-index: 8;
   margin-top: calc(50vh - 80px);
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
-  border: solid 1px var(--pale-grey);
+  border: solid 1px #e4e7ed;
   border-right: 0;
   background-color: #F7FAFF;
   text-align: center;
@@ -383,8 +383,8 @@ export default {
 }
 
 .button{
-  background-color: var(--vibrant-purple);
-  border: var(--vibrant-purple);
+  background-color: #8300bf;
+  border: #8300bf;
   color: white;
 }
 
@@ -427,7 +427,7 @@ export default {
   background-color: white !important;
 }
 .pagination>>>li.active{
-  color: var(--vibrant-purple);
+  color: #8300bf;
 }
 
 .error-feedback{
@@ -452,7 +452,7 @@ export default {
   width: 518px;
   height: calc(100vh - 20rem);
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
-  border: solid 1px var(--pale-grey);
+  border: solid 1px #e4e7ed;
   background-color: #ffffff;
   overflow-y: scroll;
 }

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -30,10 +30,9 @@
               clearable
               @clear="clearSearchClicked"
             ></el-input>
-            <el-button @click="searchEvent">Search</el-button>
+            <el-button class="button" @click="searchEvent">Search</el-button>
           </div>
           <SearchFilters class="filters" ref="filtersRef" :entry="filterEntry" @filterResults="filterUpdate" @numberPerPage="numberPerPageUpdate"></SearchFilters>
-          <el-pagination class="pagination" :current-page.sync="page" hide-on-single-page small layout="prev, pager, next" :total="numberOfHits" @current-change="pageChange"></el-pagination>
           <div class="content scrollbar"  v-loading="loadingCards" ref="content">
             <div class="card-container">
               <span v-if="results.length === 0 && !loadingCards && !sciCrunchError" class="dataset-table-title">No results for <i>{{filterFacet}}, {{lastSearch}}</i></span>
@@ -44,6 +43,7 @@
             <div v-for="o in results" :key="o.id" class="step-item">
               <DatasetCard :entry="o"></DatasetCard>
             </div>
+          <el-pagination class="pagination" :current-page.sync="page" hide-on-single-page large layout="prev, pager, next" :total="numberOfHits" @current-change="pageChange"></el-pagination>
           </div>
         </el-card>
       </div>
@@ -375,6 +375,12 @@ export default {
   pointer-events: auto;
 }
 
+.button{
+  background-color: var(--vibrant-purple);
+  border: var(--vibrant-purple);
+  color: white;
+}
+
 .box-card {
   flex: 3;
   height: 100%;
@@ -402,15 +408,15 @@ export default {
 }
 
 .pagination {
-  padding-top: 10px;
-  background-color: #F7FAFF;
+  padding-bottom: 16px;
+  background-color: white;
 }
 
 .pagination>>>button{
-  background-color: #F7FAFF !important;
+  background-color: white !important;
 }
 .pagination>>>li{
-  background-color: #F7FAFF !important;
+  background-color: white !important;
 }
 .pagination>>>li.active{
   color: var(--vibrant-purple);
@@ -496,7 +502,7 @@ export default {
 
 .content {
   width: 518px;
-  height: calc(100vh - 19.5rem);
+  height: calc(100vh - 20rem);
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
   border: solid 1px var(--pale-grey);
   background-color: #ffffff;

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -409,7 +409,6 @@ export default {
 }
 
 .header {
-  height: 50px;
   border: solid 1px #292b66;
   background-color: #292b66;
   text-align: left;

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -49,7 +49,7 @@
               :page-size="numberPerPage"
               :total="numberOfHits"
               @current-change="pageChange">
-            </el-pagination>i
+            </el-pagination>
           </div>
         </el-card>
       </div>

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -43,7 +43,16 @@
             <div v-for="o in results" :key="o.id" class="step-item">
               <DatasetCard :entry="o"></DatasetCard>
             </div>
-          <el-pagination class="pagination" :current-page.sync="page" hide-on-single-page large layout="prev, pager, next" :total="numberOfHits" @current-change="pageChange"></el-pagination>
+          <el-pagination 
+            class="pagination" 
+            :current-page.sync="page" 
+            hide-on-single-page 
+            large 
+            layout="prev, pager, next" 
+            :page-size="numberPerPage"
+            :total="numberOfHits"
+             @current-change="pageChange">
+          </el-pagination>
           </div>
         </el-card>
       </div>

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -19,7 +19,6 @@
       <div v-if="drawerOpen" @click="close" class="close-tab">
         <i class="el-icon-arrow-right"></i>
       </div>
-      <div class="splitter">
         <el-card class="box-card">
           <div slot="header" class="header">
             <el-input
@@ -41,19 +40,18 @@
             <div v-for="o in results" :key="o.id" class="step-item">
               <DatasetCard :entry="o"></DatasetCard>
             </div>
-          <el-pagination 
-            class="pagination" 
-            :current-page.sync="page" 
-            hide-on-single-page 
-            large 
-            layout="prev, pager, next" 
-            :page-size="numberPerPage"
-            :total="numberOfHits"
-             @current-change="pageChange">
-          </el-pagination>
+            <el-pagination 
+              class="pagination" 
+              :current-page.sync="page" 
+              hide-on-single-page 
+              large 
+              layout="prev, pager, next" 
+              :page-size="numberPerPage"
+              :total="numberOfHits"
+              @current-change="pageChange">
+            </el-pagination>i
           </div>
         </el-card>
-      </div>
       </div>
     </el-drawer>
   </div>
@@ -318,7 +316,6 @@ export default {
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<!-- Not that splitter flex is currently not working as width is defined by 'content' for some reason -->
 <style scoped>
 .side-bar{
   position: relative;
@@ -360,11 +357,6 @@ export default {
   pointer-events: auto;
 }
 
-.splitter{
-  display: flex;
-  flex-direction: row;
-}
-
 .close-tab{
   float: left;
   flex: 1;
@@ -400,6 +392,7 @@ export default {
   margin-bottom: 18px;
   text-align: left;
 }
+
 .search-input {
   width: 298px;
   height: 40px;
@@ -429,64 +422,11 @@ export default {
   color: var(--vibrant-purple);
 }
 
-.dataset-results-feedback {
-  width: 215px;
-  height: 16px;
-  font-family: Asap;
-  font-size: 14px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
-  letter-spacing: normal;
-  color: #292b66;
-}
-
 .error-feedback{
   font-family: Asap;
   font-size: 14px;
   font-style: italic;
   padding-top: 15px;
-}
-
-.card-container {
-  display: flex;
-  position: sticky;
-  top:0;
-  background-color: white;
-  z-index: 8;
-  padding-top: 10px;
-  height: 20px;
-  border-bottom: 1px solid var(--pale-grey);
-}
-
-.dataset-table-title {
-  flex: 1.3;
-  height: 16px;
-  font-family: Asap;
-  text-align: left !important;
-  padding-left: 16px;
-  font-size: 14px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
-  letter-spacing: normal;
-  color: var(--slate-grey);
-}
-
-.image-table-title {
-  flex: 1;
-  padding-left: 16px;
-  font-family: Asap;
-  text-align: left !important;
-  font-size: 14px;
-  font-weight: 500;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
-  letter-spacing: normal;
-  color: var(--slate-grey);
 }
 
 >>> .el-card__header {
@@ -500,20 +440,6 @@ export default {
   overflow-y: hidden;
 }
 
-.wrapper{
-  display: flex;
-  flex-direction: row;
-}
-
-.el-icon-copy-document{
-  cursor: pointer;
-  font-size: 32px;
-  width: 16px;
-  height: 16px;
-  color: #f9f9fa;
-  padding-right: 32px;
-}
-
 .content {
   width: 518px;
   height: calc(100vh - 20rem);
@@ -521,12 +447,6 @@ export default {
   border: solid 1px var(--pale-grey);
   background-color: #ffffff;
   overflow-y: scroll;
-}
-
-
-.active {
-  width: 380px !important;
-  height: 380px !important;
 }
 
 .scrollbar::-webkit-scrollbar-track {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37255664/101860355-82e2ba80-3bd2-11eb-9dac-4a003969c203.png)

Few changes:
- Switched button colors to purple
- Filter cascader now always shown
- Place div above cascader to show icon in default text
- Switch cascader to inline
- Use float to place data results feedback on right
- Modify height of sidebar now that internal size has changed
- Remove now unused css classes
- Font of results feedback now Asap
- Possibly more that I can't remember at this moment
- Swap image and dataset details order
- Remove a lot of info from dataset details
- Dataset buttons now stack vertically
- Card size now smaller and expands with extra content (no 'read more')
- Results feedback and error feedback modified to match design

UI Bug fixes:
- Pagination not recieving number per page correctly
- Search feedback sometimes expanding outside it's container

Small CSS cleanup after reduction in number of DOM objects