### PR TITLE
Switch map-sidebar from using discoverids to dois

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,11 +59,11 @@
       }
     },
     "@abi-software/map-side-bar": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-1.1.6.tgz",
-      "integrity": "sha512-NOoZBY3UCaQhBlEwUi1+nrTh1Zyg5tSi96YEY6+ZJaQs20JHv7gJOZYmzoPSzD4/XMNGhKN3N3JYMezTKbl5kA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-1.1.12.tgz",
+      "integrity": "sha512-nNwvjyiLMPI7+Vm6t+QVjjYJhfQLOU2nvYfGndNZyvfTfTaZKkO/ZV2rtXzEv+RoikKJwRJczgAdaH6N6qzjHQ==",
       "requires": {
-        "@abi-software/svg-sprite": "^0.1.12",
+        "@abi-software/svg-sprite": "^0.1.14",
         "algoliasearch": "^4.10.5",
         "element-ui": "^2.13.0",
         "vue": "^2.6.10"
@@ -133,118 +133,118 @@
       }
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.0.tgz",
-      "integrity": "sha512-l+G560B6N1k0rIcOjTO1yCzFUbg2Zy2HCii9s03e13jGgqduVQmk79UUCYszjsJ5GPJpUEKcVEtAIpP7tjsXVA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.1.tgz",
+      "integrity": "sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==",
       "requires": {
-        "@algolia/cache-common": "4.12.0"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.0.tgz",
-      "integrity": "sha512-2Z8BV+NX7oN7RmmQbLqmW8lfN9aAjOexX1FJjzB0YfKC9ifpi9Jl4nSxlnbU+iLR6QhHo0IfuyQ7wcnucCGCGQ=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.1.tgz",
+      "integrity": "sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.0.tgz",
-      "integrity": "sha512-b6ANkZF6vGAo+sYv6g25W5a0u3o6F549gEAgtTDTVA1aHcdWwe/HG/dTJ7NsnHbuR+A831tIwnNYQjRp3/V/Jw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.1.tgz",
+      "integrity": "sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==",
       "requires": {
-        "@algolia/cache-common": "4.12.0"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.0.tgz",
-      "integrity": "sha512-gzXN75ZydNheNXUN3epS+aLsKnB/PHFVlGUUjXL8WHs4lJP3B5FtHvaA/NCN5DsM3aamhuY5p0ff1XIA+Lbcrw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.1.tgz",
+      "integrity": "sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==",
       "requires": {
-        "@algolia/client-common": "4.12.0",
-        "@algolia/client-search": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.0.tgz",
-      "integrity": "sha512-rO2cZCt00Opk66QBZb7IBGfCq4ZE3EiuGkXssf2Monb5urujy0r8CknK2i7bzaKtPbd2vlvhmLP4CEHQqF6SLQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.1.tgz",
+      "integrity": "sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==",
       "requires": {
-        "@algolia/client-common": "4.12.0",
-        "@algolia/client-search": "4.12.0",
-        "@algolia/requester-common": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.0.tgz",
-      "integrity": "sha512-fcrFN7FBmxiSyjeu3sF4OnPkC1l7/8oyQ8RMM8CHpVY8cad6/ay35MrfRfgfqdzdFA8LzcBYO7fykuJv0eOqxw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.1.tgz",
+      "integrity": "sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==",
       "requires": {
-        "@algolia/requester-common": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.0.tgz",
-      "integrity": "sha512-wCJfSQEmX6ZOuJBJGjy+sbXiW0iy7tMNAhsVMV9RRaJE4727e5WAqwFWZssD877WQ74+/nF/VyTaB1+wejo33Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.1.tgz",
+      "integrity": "sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==",
       "requires": {
-        "@algolia/client-common": "4.12.0",
-        "@algolia/requester-common": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.0.tgz",
-      "integrity": "sha512-ik6dswcTQtOdZN+8aKntI9X2E6Qpqjtyda/+VANiHThY9GD2PBXuNuuC2HvlF26AbBYp5xaSE/EKxn1DIiIJ4Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.1.tgz",
+      "integrity": "sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==",
       "requires": {
-        "@algolia/client-common": "4.12.0",
-        "@algolia/requester-common": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/logger-common": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.0.tgz",
-      "integrity": "sha512-V//9rzLdJujA3iZ/tPhmKR/m2kjSZrymxOfUiF3024u2/7UyOpH92OOCrHUf023uMGYHRzyhBz5ESfL1oCdh7g=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.1.tgz",
+      "integrity": "sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.0.tgz",
-      "integrity": "sha512-pHvoGv53KXRIJHLk9uxBwKirwEo12G9+uo0sJLWESThAN3v5M+ycliU1AkUXQN8+9rds2KxfULAb+vfyfBKf8A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.1.tgz",
+      "integrity": "sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==",
       "requires": {
-        "@algolia/logger-common": "4.12.0"
+        "@algolia/logger-common": "4.12.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.0.tgz",
-      "integrity": "sha512-rGlHNMM3jIZBwSpz33CVkeXHilzuzHuFXEEW1icP/k3KW7kwBrKFJwBy42RzAJa5BYlLsTCFTS3xkPhYwTQKLg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.1.tgz",
+      "integrity": "sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==",
       "requires": {
-        "@algolia/requester-common": "4.12.0"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.0.tgz",
-      "integrity": "sha512-qgfdc73nXqpVyOMr6CMTx3nXvud9dP6GcMGDqPct+fnxogGcJsp24cY2nMqUrAfgmTJe9Nmy7Lddv0FyHjONMg=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.1.tgz",
+      "integrity": "sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.0.tgz",
-      "integrity": "sha512-mOTRGf/v/dXshBoZKNhMG00ZGxoUH9QdSpuMKYnuWwIgstN24uj3DQx+Ho3c+uq0TYfq7n2v71uoJWuiW32NMQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.1.tgz",
+      "integrity": "sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==",
       "requires": {
-        "@algolia/requester-common": "4.12.0"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.0.tgz",
-      "integrity": "sha512-MOQVHZ4BcBpf3LtOY/3fqXHAcvI8MahrXDHk9QrBE/iGensQhDiZby5Dn3o2JN/zd9FMnVbdPQ8gnkiMwZiakQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.1.tgz",
+      "integrity": "sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==",
       "requires": {
-        "@algolia/cache-common": "4.12.0",
-        "@algolia/logger-common": "4.12.0",
-        "@algolia/requester-common": "4.12.0"
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@babel/code-frame": {
@@ -3975,24 +3975,24 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "algoliasearch": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.0.tgz",
-      "integrity": "sha512-fZOMMm+F3Bi5M/MoFIz7hiuyCitJza0Hu+r8Wzz4LIQClC6YGMRq7kT6NNU1fSSoFDSeJIwMfedbbi5G9dJoVQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.1.tgz",
+      "integrity": "sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.12.0",
-        "@algolia/cache-common": "4.12.0",
-        "@algolia/cache-in-memory": "4.12.0",
-        "@algolia/client-account": "4.12.0",
-        "@algolia/client-analytics": "4.12.0",
-        "@algolia/client-common": "4.12.0",
-        "@algolia/client-personalization": "4.12.0",
-        "@algolia/client-search": "4.12.0",
-        "@algolia/logger-common": "4.12.0",
-        "@algolia/logger-console": "4.12.0",
-        "@algolia/requester-browser-xhr": "4.12.0",
-        "@algolia/requester-common": "4.12.0",
-        "@algolia/requester-node-http": "4.12.0",
-        "@algolia/transporter": "4.12.0"
+        "@algolia/cache-browser-local-storage": "4.12.1",
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/cache-in-memory": "4.12.1",
+        "@algolia/client-account": "4.12.1",
+        "@algolia/client-analytics": "4.12.1",
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-personalization": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/logger-console": "4.12.1",
+        "@algolia/requester-browser-xhr": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/requester-node-http": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "almost-equal": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@abi-software/flatmap-viewer": "^2.1.0-beta.14",
     "@abi-software/flatmapvuer": "^0.2.4-beta-1",
-    "@abi-software/map-side-bar": "^1.1.6",
+    "@abi-software/map-side-bar": "^1.1.12",
     "@abi-software/plotvuer": "^0.2.41",
     "@abi-software/scaffoldvuer": "^0.1.51",
     "@abi-software/simulationvuer": "^0.4.6",


### PR DESCRIPTION
This was a specific request from NIH figured we should switch it over. Can see the changes here:
https://github.com/ABI-Software/map-sidebar/commit/cff5d9955b56c198db1b1ab3742b73eb8ebf7147

All of our datasets are up to date and show (currently) 

I am not doing and out of date DOI checks in this version as per Andres request
