### PR TITLE
Update sidebar with the new 'Data type' filter and help popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "0.2.5-fixes-2",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -101,9 +101,9 @@
       }
     },
     "@abi-software/map-side-bar": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-1.1.13.tgz",
-      "integrity": "sha512-gTyctu9pvwc6zZyePXCQZoMw3D9S81/X3MEbmXTraqeQgs/REChmU3YXh95eAcsm1FEZnMtd2ZsEHCYjC+LKMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-1.1.17.tgz",
+      "integrity": "sha512-XGWDNujPD5/XjIz+bJjMvH6fJHI3X54Lg9vUVXAOkL0RE33FlU35kU/On91tGFGDsJNskZVloL+Dnh5XuJLKvg==",
       "requires": {
         "@abi-software/svg-sprite": "^0.1.14",
         "algoliasearch": "^4.10.5",
@@ -3423,7 +3423,7 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader-v16@16.8.3",
+          "version": "npm:vue-loader@16.8.3",
           "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
           "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@abi-software/flatmap-viewer": "2.1.0-beta.14",
     "@abi-software/flatmapvuer": "0.2.4-beta-6",
-    "@abi-software/map-side-bar": "^1.1.12",
+    "@abi-software/map-side-bar": "^1.1.17",
     "@abi-software/plotvuer": "^0.2.45",
     "@abi-software/scaffoldvuer": "^0.1.51",
     "@abi-software/simulationvuer": "^0.5.2",


### PR DESCRIPTION
This version of map-sidebar corresponds to this PR:
https://github.com/ABI-Software/map-sidebar/pull/28

Changes are: 
- Help added for filters (Gazelle request)
- New filter 'Data type'

![image](https://user-images.githubusercontent.com/37255664/162355774-13246450-8aca-4348-b7ba-cb4ef893d1fa.png)
![image](https://user-images.githubusercontent.com/37255664/162355798-6f00777d-6f4d-49dc-af37-8de2a1b93a2f.png)
