### PR TITLE
Make sure flatmapvuer works with the maplibregl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,11 +34,11 @@
       }
     },
     "@abi-software/flatmapvuer": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-0.4.5.tgz",
-      "integrity": "sha512-9Stdb+uo3aMGhAi4We0C5FQGf86EkDevkfxNE8yRFwSP6jcusFxF8ZfFRrsAFMt8lAdH3Z8jEuE1JppJq+oXbA==",
+      "version": "0.4.6-fixes-1",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-0.4.6-fixes-1.tgz",
+      "integrity": "sha512-075QwkmQ8384OwuHx+3G/qPqewuM25pRVjyuccYjmyR9ps7A251jMmG7JBmlKcrCFIfhrvgAqAxCXjQqAdX5Ew==",
       "requires": {
-        "@abi-software/flatmap-viewer": "^2.3.2-b.4",
+        "@abi-software/flatmap-viewer": "^2.3.3-b.4",
         "@abi-software/svg-sprite": "^0.1.14",
         "core-js": "^3.3.2",
         "css-element-queries": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "0.4.4",
+  "version": "0.4.4-fixes-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "0.4.4",
+  "version": "0.4.4-fixes-0",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vue-cli-service serve --port 8081",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "^0.4.5",
+    "@abi-software/flatmapvuer": "^0.4.6-fixes-1",
     "@abi-software/map-side-bar": "^1.3.38",
     "@abi-software/plotvuer": "^0.3.9",
     "@abi-software/scaffoldvuer": "^0.1.62",

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -95,7 +95,7 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
 ::v-deep .flatmapvuer-popover {
-  .mapboxgl-popup-content {
+  .maplibregl-popup-content {
     border-radius: 4px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     pointer-events: auto;


### PR DESCRIPTION
Mapbox has been renamed to maplibregl causing all css classes to be renamed, this commit addresses this issue here.