### PR TITLE
Context cards migration

### DIFF
--- a/src/components/SplitpanesBar.vue
+++ b/src/components/SplitpanesBar.vue
@@ -356,13 +356,14 @@ export default {
 
       // flatmap context update
       EventBus.$on("mapImpProv", mapImpProv => {
+        console.log('mapImpProv', mapImpProv);
 
         // check if we have a flatmap card
         let currentFlatmapCard = this.contextCardEntries.filter(entry => entry.type === 'flatmap');
 
         // if we do, modify it as opposed to adding a new one
         if (currentFlatmapCard.length > 0){
-          const slot = store.state.splitFlow.getSlotById(currentFlatmapCard[0].id);
+          const slot = store.getters["splitFlow/getSlotById"](currentFlatmapCard[0].id);
           this.contextCardVisible[slot.name] = false; // Hide flatmap card while it loads
           this.contextCardEntries[this.contextCardEntries.indexOf(currentFlatmapCard[0])] = {
             id: currentFlatmapCard[0].id,

--- a/src/components/SplitpanesBar.vue
+++ b/src/components/SplitpanesBar.vue
@@ -363,26 +363,19 @@ export default {
         // The below logic works by storing the entries info in the contextCardEntries array.
         //   These two can be compared to see if the resource has changed.
 
+        let slot = store.getters["splitFlow/getSlotById"](mapImpProv.id); 
+        this.contextCardVisible[slot.name] = false; // hide the context card when new map loads
+
         // Add card if we have more entries than before
-        if (this.entries.length > this.contextCardEntries.length){
-          let contextEntry = Object.assign({mapImpProv: mapImpProv}, this.entries[this.entries.length-1]);
+        if (this.entries.length > this.contextCardEntries.length || this.contextCardEntries.length == 0){
+          let contextEntry = Object.assign({mapImpProv: mapImpProv.prov}, this.entries[this.entries.length-1]);
           this.contextCardEntries.push(contextEntry);
-          let slot = store.getters["splitFlow/getSlotById"](contextEntry.id); 
-          this.contextCardVisible[slot] = false; // only want to show the flatmap card onclick (As it covers the minimap)
-          this.contextCardEntries.slot = slot
 
         // Check if the resource has changed and update the mapImpProv
         } else if ( this.entries.length == this.contextCardEntries.length) { 
-          for (let i in this.entries) {
-            for (let j in this.contextCardEntries){
-              if ( this.entries[i].id == this.contextCardEntries[j].id){
-                if ( this.entries[i].resource != this.contextCardEntries[j].resource){
-                  this.contextCardEntries[j] = Object.assign({mapImpProv: mapImpProv}, this.entries[i]); // update card
-                  let slot = store.getters["splitFlow/getSlotById"](this.entries[i].id); 
-                  this.contextCardVisible[slot] = false; // only want to show the flatmap card onclick (As it covers the minimap)
-                  this.contextCardEntries.slot = slot
-                }
-              }
+          for (let i in this.contextCardEntries){
+            if ( mapImpProv.id == this.contextCardEntries[i].id){
+              this.contextCardEntries[i] = Object.assign({mapImpProv: mapImpProv.prov}, this.entries.filter(ent=>ent.id==mapImpProv.id)[0]); // update card
             }
           }
         }

--- a/src/components/SplitpanesBar.vue
+++ b/src/components/SplitpanesBar.vue
@@ -59,7 +59,6 @@
               class="flatmap-context-card"
               :key="'flatmapContextCard'+i" 
               v-if="contextCardEntry.id === slot.id &&
-                    contextCardEntry.slot.name == slot.name &&
                     (contextCardEntry.type == 'Flatmap' || 
                     contextCardEntry.type == 'MultiFlatmap')" 
               :mapImpProv="contextCardEntry.mapImpProv"
@@ -67,7 +66,6 @@
             <context-card 
               :key="'contextCard'+i"
               v-if="contextCardEntry.id === slot.id &&
-                    contextCardEntry.slot.name == slot.name &&
                     contextCardEntry.type.toLowerCase() == 'scaffold'"
               :entry="contextCardEntry"
               :envVars="envVars"
@@ -313,7 +311,6 @@ export default {
       this.slotInfo.forEach( slot => this.updateisSearchableSlot(slot));
     },
     viewerChanged: function(slot, value) {
-      console.log("viewerChanged", slot, value);
       if (slot.id && slot.id != value) {
         store.commit("splitFlow/assignOrSwapIdToSlot", {
           slot: slot,
@@ -363,8 +360,6 @@ export default {
 
       // flatmap context update
       EventBus.$on("mapImpProv", mapImpProv => {
-        console.log('mapImpProv', mapImpProv);
-        window.entries = this.entries;
         // The below logic works by storing the entries info in the contextCardEntries array.
         //   These two can be compared to see if the resource has changed.
 

--- a/src/components/SplitpanesBar.vue
+++ b/src/components/SplitpanesBar.vue
@@ -145,8 +145,6 @@ export default {
       boundariesElement: null, // this is set @hook:mounted by the parent component via the 'setBoundary' method
       showDetails: true,
       contextCardEntries: [],
-      flatmapContextCardEntries: [],
-      previousEntries: [],
       isSearchable: {
         first: true,
         second: false,

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -47,7 +47,7 @@ export default {
       return this.$refs.flatmap.mapImp;
     },
     flatmapReadyCall: function (flatmap) {
-      let provClone = {...this.getFlatmapImp().provenance} //create clone of provenance
+      let provClone = {id: this.entry.id, prov: this.getFlatmapImp().provenance}; //create clone of provenance and add id
       EventBus.$emit("mapImpProv", provClone); // send clone to context card
       this.getAvailableTerms();
       if (this.entry.resource === "FunctionalConnectivity"){

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -235,7 +235,7 @@ export default {
         this.flatmapReady = true;
         const flatmapImp = flatmap.mapImp;
         this.flatmapMarkerZoomUpdate(true, flatmapImp);
-        let provClone = {...newMapImp.provenance}; //create clone of provenance
+        let provClone = {id: this.entry.id, prov: newMapImp.provenance}; //create clone of provenance
         EventBus.$emit("mapImpProv", provClone); // send provenance close to the context card for display
       }
     },


### PR DESCRIPTION
This PR updates the logic of the context cards in the split pane bar:

It now compares the new entres to past entries to see what has changed. 

It still has some limitation as unfortunately the entries of multiflatmaps are always annotated 'Rat' in the enties so it does not know which card should go where when a pane is switched in the Z direction.

