### PR TITLE
Bugfix/cypress component test

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,14 +7,6 @@ import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
-  // for cypress component test
-  // to prevent reloading after optimized dependencies changed
-  const optimizeConfig = mode !== 'development' ? null : {
-    optimizeDeps: {
-      exclude: ['vue-router'],
-    },
-  };
-
   const config = {
     css: {
         preprocessorOptions: {
@@ -57,7 +49,11 @@ export default defineConfig(({ command, mode }) => {
         },
       },
     },
-    optimizeConfig,
+    // for cypress component test
+    // to prevent reloading after optimized dependencies changed
+    optimizeDeps: {
+      exclude: ['vue-router'],
+    },
   };
 
   if (command === 'serve') {

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,14 @@ import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
+  // for cypress component test
+  // to prevent reloading after optimized dependencies changed
+  const optimizeConfig = mode !== 'development' ? null : {
+    optimizeDeps: {
+      exclude: ['vue-router'],
+    },
+  };
+
   const config = {
     css: {
         preprocessorOptions: {
@@ -29,7 +37,7 @@ export default defineConfig(({ command, mode }) => {
           ],
           dts: 'src/components.d.ts',
         }),
-    
+
         // https://github.com/antfu/unocss
         // see unocss.config.ts for config
     ],
@@ -49,6 +57,7 @@ export default defineConfig(({ command, mode }) => {
         },
       },
     },
+    optimizeConfig,
   };
 
   if (command === 'serve') {


### PR DESCRIPTION
Based on my research, the primary cause of test failures is related to **reloading** due to changes in **optimized dependencies** by Vite. I’ve noticed that these optimized dependencies consistently appear in the console output log during failed tests. To address this issue, I’ve experimented with Vite configuration and succeeded by excluding “vue-router” from dependency optimization.