### PR TITLE
Update tagging js by emitting event

### DIFF
--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -297,6 +297,12 @@ export default {
        */
       this.$emit("updateShareLinkRequested");
     });
+    EventBus.on('trackEvent', (taggingData) => {
+      /**
+       * This event triggers data tracking for Google Tag Manager (GTM) related to map interactions.
+       */
+      this.$emit('trackEvent', taggingData);
+    });
     if (!this.state) {
       this.initialState = await initialState(this.startingMap, this.options.sparcApi);
     }

--- a/src/services/tagging.js
+++ b/src/services/tagging.js
@@ -1,3 +1,4 @@
+import EventBus from '../components/EventBus';
 export default {
   sendEvent: function(data) {
     const taggingData = {
@@ -20,9 +21,7 @@ export default {
       console.table(taggingData);
     }
 
-    // push to dataLayer for GTM
-    if (typeof dataLayer !== 'undefined') {
-      dataLayer.push(taggingData);
-    }
+    // Emit data for GTM
+    EventBus.emit('trackEvent', taggingData);
   }
 }


### PR DESCRIPTION
Update data tracking with event instead of directly pushing to `dataLayer`.
This new method will need integration but will work better with the existing `nuxt-gtm`. 

### Integration

```Vue
<MapContent
  ...
  @trackEvent="onTrackEvent"
/>
<script>
  ...,
  methods: {
    ...,
    onTrackEvent: function(eventData) {
      this.$gtm.trackEvent(eventData);
    },
  }
</script>
```