### PR TITLE
Sckan version on context card

### DIFF
--- a/src/components/FlatmapContextCard.vue
+++ b/src/components/FlatmapContextCard.vue
@@ -56,22 +56,34 @@ export default {
     sckanReleaseDisplay: function() {
       let sckanRelease = "Unknown"
       if(this.mapImpProv){
-        let sckanCreated = this.mapImpProv.sckan.created ? this.mapImpProv.sckan.created : this.mapImpProv.sckan
-        let isoTime = sckanCreated.replace(',', '.') // Date time does not accept commas but Sckan uses them
-        sckanRelease = new Date(isoTime).toLocaleDateString('en-US', {
-            day: '2-digit',
-            month: 'long',
-            year: 'numeric',
-        })
+        sckanRelease = this.mapImpProv.connectivity?.npo.release
+        if (!sckanRelease) {
+          let sckanCreated = this.mapImpProv.sckan?.created ? this.mapImpProv.sckan.created : this.mapImpProv.sckan
+          let isoTime = sckanCreated.replace(',', '.') // Date time does not accept commas but Sckan uses them
+          sckanRelease = new Date(isoTime).toLocaleDateString('en-US', {
+              day: '2-digit',
+              month: 'long',
+              year: 'numeric',
+          })
+        }
+        if (!sckanRelease) {
+          sckanRelease = "Unknown";
+        }
       }
       return sckanRelease 
     },
     sckanReleaseLink: function() {
-      let sckanRelease = "Unknown"
+      let sckanLink = "Unknown"
       if(this.mapImpProv){
-        sckanRelease = this.mapImpProv.sckan.release
+        sckanLink = this.mapImpProv.connectivity?.npo.path
+        if (!sckanLink) {
+          sckanLink = this.mapImpProv.sckan?.release
+        }
+        if (!sckanLink) {
+          sckanLink = "Unknown"
+        }
       }
-      return sckanRelease 
+      return sckanLink
     },
     flatmapSource: function() {
       let flatmapSource = "Unknown"

--- a/src/components/FlatmapContextCard.vue
+++ b/src/components/FlatmapContextCard.vue
@@ -56,7 +56,7 @@ export default {
     sckanReleaseDisplay: function() {
       let sckanRelease = "Unknown"
       if(this.mapImpProv){
-        sckanRelease = this.mapImpProv.connectivity?.npo.release
+        sckanRelease = this.mapImpProv.connectivity?.npo.date
         if (!sckanRelease) {
           let sckanCreated = this.mapImpProv.sckan?.created ? this.mapImpProv.sckan.created : this.mapImpProv.sckan
           let isoTime = sckanCreated.replace(',', '.') // Date time does not accept commas but Sckan uses them


### PR DESCRIPTION
Switch to using a new string format suggested by the SCKAN experts. This new fields will be available once the maps is updated. The new format is currently available in the curation flatmap server.