### PR TITLE
Display connectivity info without obstructing current map view

### DIFF
--- a/cypress/component/MapContent.cy.js
+++ b/cypress/component/MapContent.cy.js
@@ -35,7 +35,7 @@ describe('MapContent', () => {
     //cy.intercept('GET', 'https://mapcore-demo.org/current/flatmap/v2/**');
 
     cy.mount(MapContent, {
-      propsData: {
+      props: {
         options: {
           sparcApi: "https://mock-test/sparc-api/",
           flatmapAPI: "https://mapcore-demo.org/current/flatmap/v3/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@abi-software/flatmapvuer": "^1.2.0",
         "@abi-software/map-side-bar": "^2.2.1-alpha-3",
-        "@abi-software/map-utilities": "^0.0.0-beta.4",
+        "@abi-software/map-utilities": "^0.0.0-beta.6",
         "@abi-software/plotvuer": "1.0.0",
         "@abi-software/scaffoldvuer": "^1.2.1",
         "@abi-software/simulationvuer": "1.0.0",
@@ -41,7 +41,7 @@
         "chai": "^4.1.2",
         "chokidar": "^3.6.0",
         "concurrently": "^8.2.2",
-        "cypress": "^13.6.6",
+        "cypress": "^13.13.0",
         "cypress-multi-reporters": "^1.6.4",
         "cypress-wait-until": "^1.7.1",
         "dom-parser": "^0.1.6",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@abi-software/map-utilities": {
-      "version": "0.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@abi-software/map-utilities/-/map-utilities-0.0.0-beta.4.tgz",
-      "integrity": "sha512-L6HlYPqERlSErEX/9TKxdK34ZIn1n+EgThIORLh2AhDmkMkM5uY73MbbHGyFZ/jrQL6AnHePYRZKy00pydJjbQ==",
+      "version": "0.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-utilities/-/map-utilities-0.0.0-beta.6.tgz",
+      "integrity": "sha512-7Vim8RzLUuhoRjpF55WZ/lDn/NyZiQK1rriQTAONPI5/DlWAHJdvmcIVTKuaMBl79EORe0nIMIrzB6mITSrpXQ==",
       "dependencies": {
         "@abi-software/svg-sprite": "^1.0.0",
         "@element-plus/icons-vue": "^2.3.1",
@@ -6822,9 +6822,9 @@
       "integrity": "sha512-qv8s+G47V6Hq+g2kRE5th+ASzzrL7b6l+tap1DHKK25ZQJv3yIFhH96XaQ7NGL+zRW3t/RDbweJf/dJDe5Z5KA=="
     },
     "node_modules/cypress": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.8.1.tgz",
-      "integrity": "sha512-Uk6ovhRbTg6FmXjeZW/TkbRM07KPtvM5gah1BIMp4Y2s+i/NMxgaLw0+PbYTOdw1+egE0FP3mWRiGcRkjjmhzA==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
+      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6867,7 +6867,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -20481,15 +20481,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.2.1",
+  "version": "1.2.1-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@abi-software/mapintegratedvuer",
-      "version": "1.2.1",
+      "version": "1.2.1-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "^1.2.0",
-        "@abi-software/map-side-bar": "^2.2.1-alpha-3",
+        "@abi-software/flatmapvuer": "^1.3.1",
+        "@abi-software/map-side-bar": "^2.3.0",
         "@abi-software/map-utilities": "^0.0.0-beta.6",
         "@abi-software/plotvuer": "1.0.0",
-        "@abi-software/scaffoldvuer": "^1.2.1",
+        "@abi-software/scaffoldvuer": "^1.2.1-beta.0",
         "@abi-software/simulationvuer": "1.0.0",
         "@abi-software/svg-sprite": "1.0.0",
         "@element-plus/icons-vue": "^2.3.1",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@abi-software/flatmap-viewer": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-2.9.4.tgz",
-      "integrity": "sha512-jg3aOtARBPG7U2h+0qdakjCGCWgYjFyqS2E1eqg1Pgqfk/yDUp4q73IqtNB6j1tC6qreCZw3r3/2YAbpUcgQwA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-2.9.5.tgz",
+      "integrity": "sha512-Sib5EghUvNmcTyEc4tuEDSE2UBwnBC+1qaVcaF69auwUBrcEH8A4x0kqjEd6TdUV0XF5rVnbov+addBDgdBEdg==",
       "dependencies": {
         "@deck.gl/core": "^8.9.35",
         "@deck.gl/layers": "^8.9.35",
@@ -100,11 +100,12 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.2.0.tgz",
-      "integrity": "sha512-0cXr7HOqYnQqHuyI1RaX8aa3kTFPGVgBLZ7Gww/pCGOuIusvy23NCTihlTzPQNXx3I8NBhL3CJnx6u7ur3r3gA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.1.tgz",
+      "integrity": "sha512-LFfOO8/w2ijBuZ9z2Mrhp/0IxFV6JFBTf2pZU5pB/Ovr75Lfi9BJjWQ2tpAv0TH/7bZw1/SUFB/QbtV1t+X/qQ==",
       "dependencies": {
-        "@abi-software/flatmap-viewer": "^2.9.4",
+        "@abi-software/flatmap-viewer": "2.9.5",
+        "@abi-software/map-utilities": "1.0.0",
         "@abi-software/sparc-annotation": "0.3.1",
         "@abi-software/svg-sprite": "1.0.0",
         "@element-plus/icons-vue": "^2.3.1",
@@ -114,6 +115,154 @@
         "pinia": "^2.1.7",
         "unplugin-vue-components": "^0.26.0",
         "vue": "^3.4.15"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@abi-software/map-utilities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-utilities/-/map-utilities-1.0.0.tgz",
+      "integrity": "sha512-TJiDVSXrL/u2s5FiUbaX5UQiwktoCQieRTnxi//2owDyEasqjIkK0GPUaLK+Ru3VQMbNfwFUvPd2Q2extW76cA==",
+      "dependencies": {
+        "@abi-software/svg-sprite": "^1.0.0",
+        "@element-plus/icons-vue": "^2.3.1",
+        "element-plus": "^2.7.3",
+        "mitt": "^3.0.1",
+        "vue": "^3.4.21"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@abi-software/map-utilities/node_modules/element-plus": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/element-plus/-/element-plus-2.7.6.tgz",
+      "integrity": "sha512-36sw1K23hYjgeooR10U6CiCaCp2wvOqwoFurADZVlekeQ9v5U1FhJCFGEXO6i/kZBBMwsE1c9fxjLs9LENw2Rg==",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.4.1",
+        "@element-plus/icons-vue": "^2.3.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7",
+        "@types/lodash": "^4.14.182",
+        "@types/lodash-es": "^4.17.6",
+        "@vueuse/core": "^9.1.0",
+        "async-validator": "^4.2.5",
+        "dayjs": "^1.11.3",
+        "escape-html": "^1.0.3",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "lodash-unified": "^1.0.2",
+        "memoize-one": "^6.0.0",
+        "normalize-wheel-es": "^1.2.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/compiler-core": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.31.tgz",
+      "integrity": "sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==",
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.31",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/compiler-dom": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz",
+      "integrity": "sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==",
+      "dependencies": {
+        "@vue/compiler-core": "3.4.31",
+        "@vue/shared": "3.4.31"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/compiler-sfc": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.31.tgz",
+      "integrity": "sha512-einJxqEw8IIJxzmnxmJBuK2usI+lJonl53foq+9etB2HAzlPjAS/wa7r0uUpXw5ByX3/0uswVSrjNb17vJm1kQ==",
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.31",
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/compiler-ssr": "3.4.31",
+        "@vue/shared": "3.4.31",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/compiler-ssr": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.31.tgz",
+      "integrity": "sha512-RtefmITAje3fJ8FSg1gwgDhdKhZVntIVbwupdyZDSifZTRMiWxWehAOTCc8/KZDnBOcYQ4/9VWxsTbd3wT0hAA==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/shared": "3.4.31"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/reactivity": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.31.tgz",
+      "integrity": "sha512-VGkTani8SOoVkZNds1PfJ/T1SlAIOf8E58PGAhIOUDYPC4GAmFA2u/E14TDAFcf3vVDKunc4QqCe/SHr8xC65Q==",
+      "dependencies": {
+        "@vue/shared": "3.4.31"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/runtime-core": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.31.tgz",
+      "integrity": "sha512-LDkztxeUPazxG/p8c5JDDKPfkCDBkkiNLVNf7XZIUnJ+66GVGkP+TIh34+8LtPisZ+HMWl2zqhIw0xN5MwU1cw==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.31",
+        "@vue/shared": "3.4.31"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/runtime-dom": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.31.tgz",
+      "integrity": "sha512-2Auws3mB7+lHhTFCg8E9ZWopA6Q6L455EcU7bzcQ4x6Dn4cCPuqj6S2oBZgN2a8vJRS/LSYYxwFFq2Hlx3Fsaw==",
+      "dependencies": {
+        "@vue/reactivity": "3.4.31",
+        "@vue/runtime-core": "3.4.31",
+        "@vue/shared": "3.4.31",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/server-renderer": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.31.tgz",
+      "integrity": "sha512-D5BLbdvrlR9PE3by9GaUp1gQXlCNadIZytMIb8H2h3FMWJd4oUfkUTEH2wAr3qxoRz25uxbTcbqd3WKlm9EHQA==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.31",
+        "@vue/shared": "3.4.31"
+      },
+      "peerDependencies": {
+        "vue": "3.4.31"
+      }
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/@vue/shared": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
+      "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA=="
+    },
+    "node_modules/@abi-software/flatmapvuer/node_modules/vue": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.31.tgz",
+      "integrity": "sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/compiler-sfc": "3.4.31",
+        "@vue/runtime-dom": "3.4.31",
+        "@vue/server-renderer": "3.4.31",
+        "@vue/shared": "3.4.31"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@abi-software/gallery": {
@@ -128,9 +277,9 @@
       }
     },
     "node_modules/@abi-software/map-side-bar": {
-      "version": "2.2.1-alpha-3",
-      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-2.2.1-alpha-3.tgz",
-      "integrity": "sha512-UZHW7davYE60cGGe2ima7YQXUZx996zw0mBLSBjvHIEZv2ShRUcSDQwD4jJfbv+v6QmZkQKJL0ZoUJgOEDRUVg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-2.3.0.tgz",
+      "integrity": "sha512-kcQh3/eAgeB1fOePHBO20sP4NnwKtu28ggFEfQUiw14zOpiaJ3f+2aC3TZJwWC2mhittm+5eMl98TSaR6ET+9g==",
       "dependencies": {
         "@abi-software/gallery": "^1.1.0",
         "@abi-software/svg-sprite": "^1.0.0",
@@ -314,11 +463,11 @@
       }
     },
     "node_modules/@abi-software/scaffoldvuer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@abi-software/scaffoldvuer/-/scaffoldvuer-1.2.1.tgz",
-      "integrity": "sha512-mtwkuMznxtYbRIa2klUSORe8x+UEEiUuOtqGc1MIN23OgfPZnx+rdFC4MgsdXguambGOkRMaHtV5MI/5VShd0g==",
+      "version": "1.2.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@abi-software/scaffoldvuer/-/scaffoldvuer-1.2.1-beta.0.tgz",
+      "integrity": "sha512-hU7Lf3uQH/VsTnYvFfSOvzO4ZATYb3fO+PbPgmSCXhyrr383KGGruq4aKo2B6TJ968xi/wXlJGsfTfP+SI7gbw==",
       "dependencies": {
-        "@abi-software/flatmapvuer": "^1.1.0",
+        "@abi-software/map-utilities": "^0.0.0-beta.4",
         "@abi-software/sparc-annotation": "^0.3.1",
         "@abi-software/svg-sprite": "^1.0.0",
         "@element-plus/icons-vue": "^2.3.1",
@@ -13957,9 +14106,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.4.1.tgz",
-      "integrity": "sha512-tD+wn8qWSLCGhABKBrbewmgFfyopZDz+fkYXeOM8vdBhnf126DvMPyaYGGoKvoF4QuswCsgikETd2c39wK+OQw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.0.tgz",
+      "integrity": "sha512-qOS1hn4d/pn2i0uva4S5Oz+fACzTkgBKq+NpwT/Tqzi4MSyzcWNtDELzLUSgWqHfNIkGCl5CZ/w7dtis+t4RCw==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -13977,7 +14126,7 @@
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",
@@ -13996,6 +14145,11 @@
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
+    },
+    "node_modules/maplibre-gl/node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
     },
     "node_modules/mark.js": {
       "version": "8.11.1",

--- a/package.json
+++ b/package.json
@@ -50,15 +50,16 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/map-utilities": "^0.0.0-beta.4",
     "@abi-software/flatmapvuer": "^1.2.0",
     "@abi-software/map-side-bar": "^2.2.1-alpha-3",
+    "@abi-software/map-utilities": "^0.0.0-beta.6",
     "@abi-software/plotvuer": "1.0.0",
     "@abi-software/scaffoldvuer": "^1.2.1",
     "@abi-software/simulationvuer": "1.0.0",
     "@abi-software/svg-sprite": "1.0.0",
     "@element-plus/icons-vue": "^2.3.1",
     "@pinia/testing": "^0.1.3",
+    "@vitejs/plugin-vue": "^4.6.2",
     "css-element-queries": "^1.2.3",
     "element-plus": "^2.4.4",
     "marked": "^4.3.0",
@@ -68,8 +69,7 @@
     "vue": "^3.4.15",
     "vue-router": "^4.2.5",
     "vuex": "^4.1.0",
-    "xss": "^1.0.14",
-    "@vitejs/plugin-vue": "^4.6.2"
+    "xss": "^1.0.14"
   },
   "devDependencies": {
     "@cypress/webpack-dev-server": "^3.6.1",
@@ -82,7 +82,7 @@
     "chai": "^4.1.2",
     "chokidar": "^3.6.0",
     "concurrently": "^8.2.2",
-    "cypress": "^13.6.6",
+    "cypress": "^13.13.0",
     "cypress-multi-reporters": "^1.6.4",
     "cypress-wait-until": "^1.7.1",
     "dom-parser": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.2.1",
+  "version": "1.2.1-beta.4",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vite --host --force",
@@ -50,11 +50,11 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "^1.2.0",
-    "@abi-software/map-side-bar": "^2.2.1-alpha-3",
+    "@abi-software/flatmapvuer": "^1.3.1",
+    "@abi-software/map-side-bar": "^2.3.0",
     "@abi-software/map-utilities": "^0.0.0-beta.6",
     "@abi-software/plotvuer": "1.0.0",
-    "@abi-software/scaffoldvuer": "^1.2.1",
+    "@abi-software/scaffoldvuer": "^1.2.1-beta.0",
     "@abi-software/simulationvuer": "1.0.0",
     "@abi-software/svg-sprite": "1.0.0",
     "@element-plus/icons-vue": "^2.3.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@
         :state="state"
         :shareLink="shareLink"
         :useHelpModeDialog="true"
+        :connectivityInfoSidebar="true"
         @updateShareLinkRequested="updateUUID"
         @isReady="mapIsReady"
       />

--- a/src/components/ContentBar.vue
+++ b/src/components/ContentBar.vue
@@ -186,6 +186,7 @@ export default {
           target: value
         });
         this.$nextTick(() => {
+          EventBus.emit('connectivity-info-close');
           setTimeout(() => {
             this.$emit("chooser-changed");
           }, 1200);

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -83,6 +83,13 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * The option to show connectivity info in sidebar.
+     */
+    connectivityInfoSidebar: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: function () {
     return {
@@ -319,6 +326,7 @@ export default {
     }
     this.isReady = true;
     this.settingsStore.updateUseHelpModeDialog(this.useHelpModeDialog);
+    this.settingsStore.updateConnectivityInfoSidebar(this.connectivityInfoSidebar);
   }
 }
 

--- a/src/components/SplitFlow.vue
+++ b/src/components/SplitFlow.vue
@@ -95,7 +95,6 @@ export default {
       startUp: true,
       search: '',
       activeDockedId : 1,
-      hoveredMarkerDelay: undefined,
       filterTriggered: false,
       availableFacets: [],
     }
@@ -258,16 +257,10 @@ export default {
       payload.data.cb(suggestions);
     },
     hoverChanged: function (data) {
-      const hoverEntries = data && data.anatomy ? data.anatomy : []
-      this.settingsStore.updateHoveredMarkers(hoverEntries);
-      if (!hoverEntries.length) {
-        this.hoveredMarkerDelay = setTimeout(() => {
-          EventBus.emit("markerUpdate");
-        }, 500)
-      } else {
-        clearTimeout(this.hoveredMarkerDelay)
-        EventBus.emit("markerUpdate");
-      }
+      const hoverAnatomies = data && data.anatomy ? data.anatomy : [];
+      const hoverOrgans = data && data.organs ? data.organs : [];
+      this.settingsStore.updateHoverFeatures(hoverAnatomies, hoverOrgans);
+      EventBus.emit("hoverUpdate");
     },
     searchChanged: function (data) {
       if (data && data.type == "query-update") {

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -167,6 +167,9 @@ export default {
     EventBus.on("markerUpdate", () => {
       this.flatmapMarkerUpdate(undefined);
     });
+    EventBus.on("hoverUpdate", () => {
+      this.mapHoverHighlight(this.$refs.flatmap.mapImp);
+    });
   },
 };
 </script>

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -15,6 +15,9 @@
       @help-mode-last-item="onHelpModeLastItem"
       @shown-tooltip="onTooltipShown"
       @shown-map-tooltip="onMapTooltipShown"
+      @connectivity-info-open="onConnectivityInfoOpen"
+      @connectivity-info-close="onConnectivityInfoClose"
+      :connectivityInfoSidebar="connectivityInfoSidebar"
       :pathControls="true"
       ref="flatmap"
       @ready="flatmapReadyCall"
@@ -170,6 +173,16 @@ export default {
     EventBus.on("hoverUpdate", () => {
       this.mapHoverHighlight(this.$refs.flatmap.mapImp);
     });
+    EventBus.on('show-connectivity', (payload) => {
+      const { featureIds, offset } = payload;
+      const currentFlatmap = this.$refs.flatmap;
+      if (currentFlatmap) {
+        currentFlatmap.moveMap(featureIds, {
+          offsetX: offset ? -150 : 0,
+          zoom: 4,
+        });
+      }
+    });
   },
 };
 </script>
@@ -182,7 +195,7 @@ export default {
 }
 
 :deep(.maplibregl-popup) {
-  z-index: 3;
+  z-index: 11;
 }
 
 :deep(.flatmapvuer-popover) {

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -431,6 +431,11 @@ export default {
         this.flatmapMarkerUpdate(this.$refs.multiflatmap.getCurrentFlatmap().mapImp);
       }
     });
+    EventBus.on("hoverUpdate", () => {
+      if (this.flatmapReady) {
+        this.mapHoverHighlight(this.$refs.multiflatmap.getCurrentFlatmap().mapImp);
+      }
+    });
   },
 };
 </script>
@@ -451,12 +456,6 @@ export default {
   &.standard-marker {
     cursor: pointer !important;
     z-index: 2;
-  }
-  &.hovered {
-    div {
-      scale: 2;
-      transform: translate(0px, -5px);
-    }
   }
   &.highlight-marker {
     visibility: visible !important;

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -14,6 +14,9 @@
       @help-mode-last-item="onHelpModeLastItem"
       @shown-tooltip="onTooltipShown"
       @shown-map-tooltip="onMapTooltipShown"
+      @connectivity-info-open="onConnectivityInfoOpen"
+      @connectivity-info-close="onConnectivityInfoClose"
+      :connectivityInfoSidebar="connectivityInfoSidebar"
       ref="multiflatmap"
       :displayMinimap="true"
       :showStarInLegend="showStarInLegend"
@@ -52,7 +55,7 @@ import {
 import DyncamicMarkerMixin from "../../mixins/DynamicMarkerMixin";
 
 import YellowStar from "../../icons/yellowstar";
-  
+
 import { MultiFlatmapVuer } from "@abi-software/flatmapvuer";
 import "@abi-software/flatmapvuer/dist/style.css";
 import { HelpModeDialog } from '@abi-software/map-utilities'
@@ -309,6 +312,7 @@ export default {
           await this.toggleSyncMode();
       }
       this.updateProvCard();
+      this.onConnectivityInfoClose();
 
       // GA Tagging
       // Event tracking for maps' species change
@@ -426,6 +430,19 @@ export default {
     this.getAvailableTerms();
     this.getFeaturedDatasets();
 
+    EventBus.on('show-connectivity', (payload) => {
+      const { featureIds, offset } = payload;
+      if (this.flatmapReady && this.$refs.multiflatmap) {
+        const currentFlatmap = this.$refs.multiflatmap.getCurrentFlatmap();
+        if (currentFlatmap) {
+          currentFlatmap.moveMap(featureIds, {
+            offsetX: offset ? -150 : 0,
+            zoom: 4,
+          });
+        }
+      }
+    });
+
     EventBus.on("markerUpdate", () => {
       if (this.flatmapReady) {
         this.flatmapMarkerUpdate(this.$refs.multiflatmap.getCurrentFlatmap().mapImp);
@@ -449,7 +466,7 @@ export default {
 }
 
 :deep(.maplibregl-popup) {
-  z-index: 3;
+  z-index: 11;
 }
 
 :deep(.maplibregl-marker) {

--- a/src/components/viewers/Scaffold.vue
+++ b/src/components/viewers/Scaffold.vue
@@ -209,6 +209,11 @@ export default {
     EventBus.on("startHelp", () => {
       this.startHelp();
     });
+    EventBus.on("hoverUpdate", () => {
+      if (this.scaffoldLoaded) {
+        this.mapHoverHighlight(this.$refs.scaffold);
+      }
+    });
   },
 };
 </script>

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -486,6 +486,28 @@ export default {
         this.endHelp();
       }
     },
+    mapHoverHighlight: function (mapImp) {
+      if (this.visible) {
+        const hoverAnatomies = this.settingsStore.hoverAnatomies;
+        const hoverOrgans = this.settingsStore.hoverOrgans;
+        if (hoverAnatomies.length || hoverOrgans.length) {
+          clearTimeout(this.hoverDelay);
+          if (this.multiflatmapRef || this.flatmapRef) {
+            mapImp?.zoomToFeatures(hoverAnatomies, { noZoomIn: true });
+          } else if (this.scaffoldRef) {
+            mapImp?.changeHighlightedByName(hoverOrgans, "", false);
+          }
+        } else {
+          this.hoverDelay = setTimeout(() => {
+            if (this.multiflatmapRef || this.flatmapRef) {
+              mapImp?.clearSearchResults();
+            } else if (this.scaffoldRef) {
+              mapImp?.changeHighlightedByName(hoverOrgans, "", false);
+            }
+          }, 500);
+        }
+      }
+    }
   },
   data: function () {
     return {
@@ -506,6 +528,7 @@ export default {
       idNamePair: {},
       scaffoldLoaded: false,
       isInHelp: false,
+      hoverDelay: undefined
     };
   },
   created: function () {

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -41,6 +41,9 @@ export default {
     useHelpModeDialog() {
       return this.settingsStore.useHelpModeDialog;
     },
+    connectivityInfoSidebar() {
+      return this.settingsStore.connectivityInfoSidebar;
+    },
   },
   mounted: function () {
     EventBus.on("startHelp", () => {
@@ -66,6 +69,8 @@ export default {
         EventBus.emit("OpenNewMap", type);
         this.trackOpenMap(`open_new_${type}_map`);
       }
+
+      this.onConnectivityInfoClose();
     },
     trackOpenMap: function (category) {
       // GA Tagging
@@ -507,7 +512,13 @@ export default {
           }, 500);
         }
       }
-    }
+    },
+    onConnectivityInfoOpen: function (connectivityInfoData) {
+      EventBus.emit('connectivity-info-open', connectivityInfoData);
+    },
+    onConnectivityInfoClose: function () {
+      EventBus.emit('connectivity-info-close');
+    },
   },
   data: function () {
     return {

--- a/src/mixins/DynamicMarkerMixin.js
+++ b/src/mixins/DynamicMarkerMixin.js
@@ -48,22 +48,6 @@ export default {
         flatmapImp.clearMarkers();
         flatmapImp.clearDatasetMarkers();
         flatmapImp.addDatasetMarkers(fmMarkers);
-      
-        // Set the hovered markers
-        let hoveredMarkers = this.settingsStore.hoveredMarkers
-        let previousHoveredMarkers = this.settingsStore.previousHoveredMarkers
-        hoveredMarkers.forEach(id => {
-          let markerClass = "standard-marker" + " hovered" // Space-separated CSS class names
-          let markerCluster = false // Disable cluster when related dataset is hovered
-          flatmapImp.addMarker(id, { className: markerClass, cluster: markerCluster })
-        })
-        if (previousHoveredMarkers !== null && previousHoveredMarkers.length >= 0) {
-          previousHoveredMarkers.forEach(id => {
-            let markerClass = "standard-marker"
-            let markerCluster = true
-            flatmapImp.addMarker(id, { className: markerClass, cluster: markerCluster })
-          })
-        } 
 
         // Set the featured markers
         if (this.entry.type === "MultiFlatmap") {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -26,6 +26,7 @@ export const useSettingsStore = defineStore('settings', {
       featuredDatasetIdentifiers: [],
       helpDelay: 0,
       useHelpModeDialog: false,
+      connectivityInfoSidebar: false,
     }
   },
   getters: {
@@ -149,6 +150,9 @@ export const useSettingsStore = defineStore('settings', {
     },
     updateUseHelpModeDialog(helpModeOption) {
       this.useHelpModeDialog = helpModeOption;
+    },
+    updateConnectivityInfoSidebar(connectivityInfoSidebar) {
+      this.connectivityInfoSidebar = connectivityInfoSidebar;
     },
   }
 });

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -17,8 +17,8 @@ export const useSettingsStore = defineStore('settings', {
       facets: { species: [], gender: [], organ: [] },
       numberOfDatasetsForFacets: [],
       markers: [],
-      hoveredMarkers: [],
-      previousHoveredMarkers: null,
+      hoverAnatomies: [],
+      hoverOrgans: [],
       featuredMarkers: [],
       featuredMarkerIdentifiers: [],
       featuredMarkerDois: [],
@@ -70,9 +70,9 @@ export const useSettingsStore = defineStore('settings', {
     updateMarkers(markers) {
       this.markers = markers;
     },
-    updateHoveredMarkers(markers) {
-      this.previousHoveredMarkers = this.hoveredMarkers;
-      this.hoveredMarkers = markers;
+    updateHoverFeatures(anatomies, organs) {
+      this.hoverAnatomies = anatomies;
+      this.hoverOrgans = organs;
     },
     updateFeatured(datasetIdentifiers) {
       this.featuredMarkerIdentifiers = new Array(datasetIdentifiers.length);


### PR DESCRIPTION
The original task was to show the provenance info in the sidebar.
[Wrike ticket](https://www.wrike.com/open.htm?id=1382421956)
There are 3 PRs related to this.

1. https://github.com/ABI-Software/map-sidebar/pull/74
2. https://github.com/ABI-Software/flatmapvuer/pull/175

### Usage
The following property must be set to true to show the provenance info in the sidebar. (It is already done in `App.vue` for demo).
```
connectivityInfoSidebar="true"
```
The provenance info will show as a popup (default style) if it is set to `false` or not provided.