### PR TITLE
Set connectivity info in sidebar as default

### DIFF
--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -85,10 +85,11 @@ export default {
     },
     /**
      * The option to show connectivity info in sidebar.
+     * Default is `true`. Set `false` to show as popup on map.
      */
     connectivityInfoSidebar: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
   data: function () {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -26,7 +26,7 @@ export const useSettingsStore = defineStore('settings', {
       featuredDatasetIdentifiers: [],
       helpDelay: 0,
       useHelpModeDialog: false,
-      connectivityInfoSidebar: false,
+      connectivityInfoSidebar: true,
     }
   },
   getters: {


### PR DESCRIPTION
This PR is to set the connectivity info in the sidebar as default for the following PR.
https://github.com/nih-sparc/sparc-app-2/pull/158