### PR TITLE
Update beta version 1.3.3-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.4-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "1.3.2-beta.1",
+        "@abi-software/flatmapvuer": "^1.3.2",
         "@abi-software/map-side-bar": "^2.3.1",
         "@abi-software/map-utilities": "^1.0.0",
         "@abi-software/plotvuer": "1.0.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.3.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.2-beta.1.tgz",
-      "integrity": "sha512-pSPKW83UmbLsw3AtYJ9XJxIffVtj+kZI4bPBZfAx+sShXZL/HcQ0HsHjl6zcsBR4CcoRCm2cGgZePCIw9U6TxA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.2.tgz",
+      "integrity": "sha512-CGEPhD3y9MVVzqKwFDa1jrakpvErv30eSH5Ji0Qg8ulbWYtvMmcp+qr1LPPNDSP1zhf9Y/5lqecZlXQsW/H5hQ==",
       "dependencies": {
         "@abi-software/flatmap-viewer": "2.9.5",
         "@abi-software/map-utilities": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.3-beta.0",
+  "version": "1.3.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@abi-software/mapintegratedvuer",
-      "version": "1.3.3-beta.0",
+      "version": "1.3.4-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "^1.3.1-beta.0",
+        "@abi-software/flatmapvuer": "1.3.2-beta.0",
         "@abi-software/map-side-bar": "^2.3.1",
         "@abi-software/map-utilities": "^1.0.0",
         "@abi-software/plotvuer": "1.0.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.3.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.1-beta.0.tgz",
-      "integrity": "sha512-i/CpW6cbrnRwM+MKFPCN/FpIB/a2bjB6IfD6jMXsizaeMv0GMvk1Pi1zJHUri9sDVqwNNGvkhccTH8POf3ZkKw==",
+      "version": "1.3.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.2-beta.0.tgz",
+      "integrity": "sha512-XCTk192Z1+eaIlby21001DGVUUPfNRNkBOPu9dB+XR26iW0oaM9K/iOIAWqMJt8O0YRwPtaKVaL1DSto8V1/LA==",
       "dependencies": {
         "@abi-software/flatmap-viewer": "2.9.5",
         "@abi-software/map-utilities": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.4-beta.0",
+  "version": "1.3.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@abi-software/mapintegratedvuer",
-      "version": "1.3.4-beta.0",
+      "version": "1.3.4-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "1.3.2-beta.0",
+        "@abi-software/flatmapvuer": "1.3.2-beta.1",
         "@abi-software/map-side-bar": "^2.3.1",
         "@abi-software/map-utilities": "^1.0.0",
         "@abi-software/plotvuer": "1.0.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.3.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.2-beta.0.tgz",
-      "integrity": "sha512-XCTk192Z1+eaIlby21001DGVUUPfNRNkBOPu9dB+XR26iW0oaM9K/iOIAWqMJt8O0YRwPtaKVaL1DSto8V1/LA==",
+      "version": "1.3.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.2-beta.1.tgz",
+      "integrity": "sha512-pSPKW83UmbLsw3AtYJ9XJxIffVtj+kZI4bPBZfAx+sShXZL/HcQ0HsHjl6zcsBR4CcoRCm2cGgZePCIw9U6TxA==",
       "dependencies": {
         "@abi-software/flatmap-viewer": "2.9.5",
         "@abi-software/map-utilities": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.3",
+  "version": "1.3.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@abi-software/mapintegratedvuer",
-      "version": "1.3.3",
+      "version": "1.3.3-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "^1.3.1",
+        "@abi-software/flatmapvuer": "^1.3.1-beta.0",
         "@abi-software/map-side-bar": "^2.3.1",
         "@abi-software/map-utilities": "^1.0.0",
         "@abi-software/plotvuer": "1.0.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.1.tgz",
-      "integrity": "sha512-LFfOO8/w2ijBuZ9z2Mrhp/0IxFV6JFBTf2pZU5pB/Ovr75Lfi9BJjWQ2tpAv0TH/7bZw1/SUFB/QbtV1t+X/qQ==",
+      "version": "1.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.3.1-beta.0.tgz",
+      "integrity": "sha512-i/CpW6cbrnRwM+MKFPCN/FpIB/a2bjB6IfD6jMXsizaeMv0GMvk1Pi1zJHUri9sDVqwNNGvkhccTH8POf3ZkKw==",
       "dependencies": {
         "@abi-software/flatmap-viewer": "2.9.5",
         "@abi-software/map-utilities": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.3-beta.0",
+  "version": "1.3.4-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vite --host --force",
@@ -50,7 +50,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "^1.3.1-beta.0",
+    "@abi-software/flatmapvuer": "1.3.2-beta.0",
     "@abi-software/map-side-bar": "^2.3.1",
     "@abi-software/map-utilities": "^1.0.0",
     "@abi-software/plotvuer": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.3",
+  "version": "1.3.3-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vite --host --force",
@@ -50,7 +50,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "^1.3.1",
+    "@abi-software/flatmapvuer": "^1.3.1-beta.0",
     "@abi-software/map-side-bar": "^2.3.1",
     "@abi-software/map-utilities": "^1.0.0",
     "@abi-software/plotvuer": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/mapintegratedvuer",
-  "version": "1.3.4-beta.0",
+  "version": "1.3.4-beta.1",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "vite --host --force",
@@ -50,7 +50,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "1.3.2-beta.0",
+    "@abi-software/flatmapvuer": "1.3.2-beta.1",
     "@abi-software/map-side-bar": "^2.3.1",
     "@abi-software/map-utilities": "^1.0.0",
     "@abi-software/plotvuer": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "1.3.2-beta.1",
+    "@abi-software/flatmapvuer": "^1.3.2",
     "@abi-software/map-side-bar": "^2.3.1",
     "@abi-software/map-utilities": "^1.0.0",
     "@abi-software/plotvuer": "1.0.0",


### PR DESCRIPTION
This is to hide connectivity info for empty data.
The following PR for Flatmapvuer is the fix on Flatmapvuer.
[Hide connectivity info for empty tooltip data #179](https://github.com/ABI-Software/flatmapvuer/pull/179)