### PR TITLE
Solve markers conflict

### DIFF
--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -479,6 +479,7 @@ export default {
     div {
       scale: 0.5;
       transform: translate(45px, -7px);
+      width: 0;
     }
   }
 }

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -478,7 +478,6 @@ export default {
     z-index: 1;
     div {
       scale: 0.5;
-      transform: translate(45px, -7px);
       width: 0;
     }
   }


### PR DESCRIPTION
Set the yellowstar container width to 0. Avoid the div container covering the flatmap organ.

The issue should be fixed, no issue to click on the clustering marker in the featured marker area.

<img width="200" height="150" alt="Screenshot 2024-07-25 at 11 50 26 AM" src="https://github.com/user-attachments/assets/8dd476b4-bb9e-4ab7-849f-6bbe4841f073">

<img width="200" height="150" alt="Screenshot 2024-07-25 at 11 51 14 AM" src="https://github.com/user-attachments/assets/9b3cdade-ea44-49b9-b13c-0d500b943968">