### PR TITLE
Close sidebar on species change

### DIFF
--- a/src/components/ContentVuer.vue
+++ b/src/components/ContentVuer.vue
@@ -121,6 +121,7 @@ export default {
     },
     speciesChanged: function (species) {
       this.activeSpecies = species;
+      this.$emit("species-changed", species);
     },
     receiveSynchronisedEvent: async function (data) {
       this.$refs.viewer?.receiveSynchronisedEvent(data);

--- a/src/components/SplitDialog.vue
+++ b/src/components/SplitDialog.vue
@@ -15,6 +15,7 @@
         :entry="entry"
         ref="content"
         @resource-selected="resourceSelected"
+        @species-changed="speciesChanged"
         :visible="isIdVisible(entry.id)"
       />
     </div>
@@ -55,6 +56,9 @@ export default {
      */
     resourceSelected: function(result) {
       this.$emit("resource-selected", result);
+    },
+    speciesChanged: function (species) {
+      this.$emit("species-changed", species);
     },
     getClass: function(id) {
       if (this.isIdVisible(id)) {

--- a/src/components/SplitFlow.vue
+++ b/src/components/SplitFlow.vue
@@ -41,6 +41,7 @@
           :entries="entries"
           ref="splitdialog"
           @resource-selected="resourceSelected"
+          @species-changed="speciesChanged"
         />
       </div>
     </el-main>
@@ -449,6 +450,11 @@ export default {
       this.$emit("resource-selected", result);
       if (this.splitFlowStore.globalCallback) {
         this.$refs.splitdialog.sendSynchronisedEvent(result);
+      }
+    },
+    speciesChanged: function (species) {
+      if (this.$refs.sideBar) {
+        this.$refs.sideBar.close();
       }
     },
     tabClicked: function ({id, type}) {


### PR DESCRIPTION
When the sidebar is opened, it covers most areas of the map. Upon changing the species, the user may want to view the updated species map first. I'm trying to improve the usability of this interaction. 