### PR TITLE
Make sure contextual information does not flip up.

### DIFF
--- a/src/components/ContentBar.vue
+++ b/src/components/ContentBar.vue
@@ -149,10 +149,22 @@ export default {
     },
     popperOptions: function() {
       return {
-        preventOverflow: {
-          enabled: true,
-          boundary: this.boundariesElement,
-        }
+        modifiers: [
+          {
+            name: 'preventOverflow',
+            options: {
+              boundary: this.boundariesElement,
+            }
+          },
+          {
+            name: 'flip',
+            options: {
+              boundary: this.boundariesElement,
+              flipVariations: false,
+              allowedAutoPlacements: ['bottom'],
+            }
+          },
+        ]
       }
     },
     entries: function() {

--- a/src/components/ContentVuer.vue
+++ b/src/components/ContentVuer.vue
@@ -117,7 +117,7 @@ export default {
       this.$refs.viewer?.searchSuggestions(term, suggestions);
     },
     setPanesBoundary: function() {
-      this.$refs.contentBar?.setBoundary(this.$refs["container"][0]);
+      this.$refs.contentBar?.setBoundary(this.$refs["container"]);
     },
     speciesChanged: function (species) {
       this.activeSpecies = species;


### PR DESCRIPTION
Contextual information popup may flip to another panel when the container is not large enough. This is due to an update on the options with the popup library component. This pull request include updating the options to work with the new format.