### PR TITLE
UI Fixes

### DIFF
--- a/src/components/ContentBar.vue
+++ b/src/components/ContentBar.vue
@@ -337,6 +337,21 @@ export default {
   position: relative;
   top: auto;
   font-size: 12px;
+  align-items: center;
+
+  :deep(.el-tooltip__trigger) {
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  .hide {
+    margin-top: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+  }
 }
 
 .info-icon {

--- a/src/components/DialogToolbarContent.vue
+++ b/src/components/DialogToolbarContent.vue
@@ -306,6 +306,10 @@ export default {
         view,
         entries: this.entriesStore.entries,
       });
+
+      if (this.$refs.viewPopover) {
+        this.$refs.viewPopover.hide();
+      }
     }
   },
   mounted: function () {

--- a/src/components/DialogToolbarContent.vue
+++ b/src/components/DialogToolbarContent.vue
@@ -437,6 +437,7 @@ export default {
   padding: 4px 8px 12px 8px;
   min-width:unset!important;
   width:unset!important;
+  background-color: #f3ecf6;
   cursor:default;
   .el-popper__arrow {
     &:before {


### PR DESCRIPTION
1. `Show information` and `Remove` buttons alignment.
<table>
<tr>
<td>Odd alignment before</td>
<td><img src="https://github.com/user-attachments/assets/4d80b0f1-0095-4159-8631-b7d8eaf85af6" width="200"></td>
</tr>
<tr>
<td>After</td>
<td><img src="https://github.com/user-attachments/assets/9a344023-2190-4605-9ca3-1720dabe7f5a" width="200"></td>
</tr>
</table>

2. Hide the split view tooltip after clicking a button inside.
3. Make the split view tooltip background the same as on the portal.
<img src="https://github.com/user-attachments/assets/e17f26c4-0b25-4daf-9e5b-41289384cd96" width="200"/>

