### PR TITLE
Highlight connected paths for features

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,8 @@
                 <el-button @click="setScaffold()" size="small">Set To Scaffold</el-button>
                 <el-button @click="setFlatmap()" size="small">Set Flatmap</el-button>
                 <el-button @click="setSearch()" size="small">Set Search</el-button>
+                <el-button @click="toggleHighlightConnectedPaths()" size="small">Toggle Highlight Connected Paths</el-button>
+                <el-button @click="toggleHighlightDOIPaths()" size="small">Toggle Highlight DOI Paths</el-button>
               </div>
             </div>
             <template #reference>
@@ -40,6 +42,7 @@
         :shareLink="shareLink"
         :useHelpModeDialog="true"
         :connectivityInfoSidebar="true"
+        :hoverHighlightOptions="hoverHighlightOptions"
         @updateShareLinkRequested="updateUUID"
         @isReady="viewerIsReady"
         @mapLoaded="mapIsLoaded"
@@ -77,7 +80,11 @@ export default {
       api: import.meta.env.VITE_API_LOCATION,
       mapSettings: [],
       startingMap: "AC",
-      ElIconSetting: shallowRef(ElIconSetting)
+      ElIconSetting: shallowRef(ElIconSetting),
+      hoverHighlightOptions: {
+        highlightConnectedPaths: true,
+        highlightDOIPaths: false,
+      },
     }
   },
   computed: {
@@ -167,6 +174,12 @@ export default {
     },
     setSearch: function() {
       this.$refs.map.openSearch([], "10.26275/1uno-tynt");
+    },
+    toggleHighlightConnectedPaths: function () {
+      this.hoverHighlightOptions.highlightConnectedPaths = !this.hoverHighlightOptions.highlightConnectedPaths;
+    },
+    toggleHighlightDOIPaths: function () {
+      this.hoverHighlightOptions.highlightDOIPaths = !this.hoverHighlightOptions.highlightDOIPaths;
     },
     mapIsLoaded: function(map) {
       console.log("map is loaded", map)

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -99,6 +99,17 @@ export default {
       type: Boolean,
       default: true,
     },
+    /**
+     * The options to highlight features and paths on maps and scaffolds
+     * when hover over the dataset cards on sidebar.
+     */
+    hoverHighlightOptions: {
+      type: Object,
+      default: () => ({
+        highlightConnectedPaths: false,
+        highlightDOIPaths: false,
+      }),
+    },
   },
   data: function () {
     return {
@@ -357,6 +368,7 @@ export default {
     this.settingsStore.updateUseHelpModeDialog(this.useHelpModeDialog);
     this.settingsStore.updateConnectivityInfoSidebar(this.connectivityInfoSidebar);
     this.settingsStore.updateAnnotationSidebar(this.annotationSidebar);
+    this.settingsStore.updateHoverHighlightOptions(this.hoverHighlightOptions);
   }
 }
 

--- a/src/components/SplitFlow.vue
+++ b/src/components/SplitFlow.vue
@@ -315,7 +315,8 @@ export default {
     hoverChanged: function (data) {
       const hoverAnatomies = data && data.anatomy ? data.anatomy : [];
       const hoverOrgans = data && data.organs ? data.organs : [];
-      this.settingsStore.updateHoverFeatures(hoverAnatomies, hoverOrgans);
+      const hoverDOI = data && data.doi ? data.doi : '';
+      this.settingsStore.updateHoverFeatures(hoverAnatomies, hoverOrgans, hoverDOI);
       EventBus.emit("hoverUpdate");
     },
     searchChanged: function (data) {

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -183,7 +183,7 @@ export default {
       this.flatmapMarkerUpdate(undefined);
     });
     EventBus.on("hoverUpdate", () => {
-      this.mapHoverHighlight(this.$refs.flatmap.mapImp);
+      this.mapHoverHighlight();
     });
     EventBus.on('show-connectivity', (payload) => {
       const { featureIds, offset } = payload;

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -482,7 +482,7 @@ export default {
     });
     EventBus.on("hoverUpdate", () => {
       if (this.flatmapReady) {
-        this.mapHoverHighlight(this.$refs.multiflatmap.getCurrentFlatmap().mapImp);
+        this.mapHoverHighlight();
       }
     });
   },

--- a/src/components/viewers/Scaffold.vue
+++ b/src/components/viewers/Scaffold.vue
@@ -219,7 +219,7 @@ export default {
     });
     EventBus.on("hoverUpdate", () => {
       if (this.scaffoldLoaded) {
-        this.mapHoverHighlight(this.$refs.scaffold);
+        this.mapHoverHighlight();
       }
     });
   },

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -484,14 +484,30 @@ export default {
 
       return itemsToHighlight;
     },
-    mapHoverHighlight: function (mapImp) {
+    mapHoverHighlight: function () {
       if (this.visible) {
         const hoverAnatomies = this.settingsStore.hoverAnatomies;
         const hoverOrgans = this.settingsStore.hoverOrgans;
         const hoverDOI = this.settingsStore.hoverDOI;
+        let mapImp = null;
+        let scaffold = null;
+
+        if (this.flatmapRef) {
+          mapImp = this.$refs.flatmap.mapImp;
+        }
+
+        if (this.multiflatmapRef) {
+          mapImp = this.$refs.multiflatmap.getCurrentFlatmap().mapImp;
+        }
+
+        if (this.scaffoldRef) {
+          scaffold = this.$refs.scaffold;
+        }
 
         // reset
-        mapImp?.clearSearchResults();
+        if (mapImp) {
+          mapImp.clearSearchResults();
+        }
 
         if (hoverAnatomies.length || hoverOrgans.length) {
           clearTimeout(this.hoverDelay);
@@ -500,14 +516,14 @@ export default {
               mapImp.selectFeatures(itemsToHighlight);
             });
           } else if (this.scaffoldRef) {
-            mapImp?.changeHighlightedByName(hoverOrgans, "", false);
+            scaffold?.changeHighlightedByName(hoverOrgans, "", false);
           }
         } else {
           this.hoverDelay = setTimeout(() => {
             if (this.multiflatmapRef || this.flatmapRef) {
               mapImp?.clearSearchResults();
             } else if (this.scaffoldRef) {
-              mapImp?.changeHighlightedByName(hoverOrgans, "", false);
+              scaffold?.changeHighlightedByName(hoverOrgans, "", false);
             }
           }, 500);
         }

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -472,10 +472,14 @@ export default {
         }
       });
     },
+    highlightFeaturesByDOI: function (mapImp, hoverDOI) {
+      // TODO
+    },
     mapHoverHighlight: function (mapImp) {
       if (this.visible) {
         const hoverAnatomies = this.settingsStore.hoverAnatomies;
         const hoverOrgans = this.settingsStore.hoverOrgans;
+        const hoverDOI = this.settingsStore.hoverDOI;
 
         // reset
         mapImp?.clearSearchResults();
@@ -483,7 +487,13 @@ export default {
         if (hoverAnatomies.length || hoverOrgans.length) {
           clearTimeout(this.hoverDelay);
           if (this.multiflatmapRef || this.flatmapRef) {
-            this.highlightFeaturesAndConnectivities(mapImp, hoverAnatomies);
+            if (this.highlightFeaturesAndPaths) {
+              this.highlightFeaturesAndConnectivities(mapImp, hoverAnatomies);
+            } else if (this.highlightByDOI) {
+              this.highlightFeaturesByDOI(mapImp, hoverDOI);
+            } else {
+              mapImp?.zoomToFeatures(hoverAnatomies, { noZoomIn: true });
+            }
           } else if (this.scaffoldRef) {
             mapImp?.changeHighlightedByName(hoverOrgans, "", false);
           }
@@ -534,6 +544,8 @@ export default {
       isInHelp: false,
       hoverDelay: undefined,
       mapManager: undefined,
+      highlightFeaturesAndPaths: false,
+      highlightByDOI: false,
     };
   },
   created: function () {

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -458,14 +458,32 @@ export default {
         this.endHelp();
       }
     },
+    highlightFeaturesAndConnectivities: function (mapImp, hoverAnatomies) {
+      const queryPathsForFeatures = mapImp.queryPathsForFeatures(hoverAnatomies);
+
+      queryPathsForFeatures.then((connectedPaths) => {
+        if (connectedPaths.length) {
+          mapImp.selectFeatures([
+            ...hoverAnatomies,
+            ...connectedPaths,
+          ]);
+        } else {
+          mapImp?.zoomToFeatures(hoverAnatomies, { noZoomIn: true });
+        }
+      });
+    },
     mapHoverHighlight: function (mapImp) {
       if (this.visible) {
         const hoverAnatomies = this.settingsStore.hoverAnatomies;
         const hoverOrgans = this.settingsStore.hoverOrgans;
+
+        // reset
+        mapImp?.clearSearchResults();
+
         if (hoverAnatomies.length || hoverOrgans.length) {
           clearTimeout(this.hoverDelay);
           if (this.multiflatmapRef || this.flatmapRef) {
-            mapImp?.zoomToFeatures(hoverAnatomies, { noZoomIn: true });
+            this.highlightFeaturesAndConnectivities(mapImp, hoverAnatomies);
           } else if (this.scaffoldRef) {
             mapImp?.changeHighlightedByName(hoverOrgans, "", false);
           }

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -465,9 +465,10 @@ export default {
     },
     highlightAnatomies: async function (mapImp, hoverAnatomies, hoverDOI) {
       const itemsToHighlight = [...hoverAnatomies];
+      const hoverHighlightOptions = this.settingsStore.hoverHighlightOptions;
 
       // to highlight connected paths
-      if (this.highlightFeaturesAndPaths) {
+      if (hoverHighlightOptions.highlightConnectedPaths) {
         const connectionsFromFeatures = await mapImp.queryPathsForFeatures(hoverAnatomies);
         if (connectionsFromFeatures) {
           itemsToHighlight.push(...connectionsFromFeatures);
@@ -475,7 +476,7 @@ export default {
       }
 
       // to highlight related paths from reference DOI
-      if (this.highlightDOIPaths) {
+      if (hoverHighlightOptions.highlightDOIPaths) {
         const connectionsFromDOI = await this.getConnectivitiesByDOI(hoverDOI);
         if (connectionsFromDOI) {
           itemsToHighlight.push(...connectionsFromDOI);
@@ -565,8 +566,6 @@ export default {
       isInHelp: false,
       hoverDelay: undefined,
       mapManager: undefined,
-      highlightFeaturesAndPaths: false,
-      highlightDOIPaths: false,
     };
   },
   created: function () {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -20,6 +20,7 @@ export const useSettingsStore = defineStore('settings', {
       markers: [],
       hoverAnatomies: [],
       hoverOrgans: [],
+      hoverDOI: '',
       featuredMarkers: [],
       featuredMarkerIdentifiers: [],
       featuredMarkerDois: [],
@@ -76,9 +77,10 @@ export const useSettingsStore = defineStore('settings', {
     updateMarkers(markers) {
       this.markers = markers;
     },
-    updateHoverFeatures(anatomies, organs) {
+    updateHoverFeatures(anatomies, organs, doi) {
       this.hoverAnatomies = anatomies;
       this.hoverOrgans = organs;
+      this.hoverDOI = doi;
     },
     updateFeatured(datasetIdentifiers) {
       this.featuredMarkerIdentifiers = new Array(datasetIdentifiers.length);

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -30,6 +30,10 @@ export const useSettingsStore = defineStore('settings', {
       useHelpModeDialog: false,
       connectivityInfoSidebar: true,
       annotationSidebar: true,
+      hoverHighlightOptions: {
+        highlightConnectedPaths: false,
+        highlightDOIPaths: false,
+      },
     }
   },
   getters: {
@@ -163,6 +167,9 @@ export const useSettingsStore = defineStore('settings', {
     },
     updateAnnotationSidebar(annotationSidebar) {
       this.annotationSidebar = annotationSidebar;
+    },
+    updateHoverHighlightOptions(hoverHighlightOptions) {
+      this.hoverHighlightOptions = hoverHighlightOptions;
     },
   }
 });


### PR DESCRIPTION
The options are added in the `props` -
```
hoverHighlightOptions: {
  highlightConnectedPaths: false,
  highlightDOIPaths: false,
}
```
This feature has a dependency on https://github.com/ABI-Software/flatmapvuer/pull/230 for `flatmapvuer`'s `searchConnectivitiesByReference` method.