### PR TITLE
Close tooltip on flatmap when connectivity explorer item is closed

### DIFF
--- a/src/components/SplitFlow.vue
+++ b/src/components/SplitFlow.vue
@@ -46,6 +46,7 @@
           @connectivity-hovered="onConnectivityHovered"
           @connectivity-explorer-clicked="onConnectivityExplorerClicked"
           @connectivity-source-change="onConnectivitySourceChange"
+          @connectivity-item-close="onConnectivityItemClose"
         />
         <SplitDialog
           :entries="entries"
@@ -153,6 +154,9 @@ export default {
     onConnectivityExplorerClicked: function (payload) {
       this.search = payload.id
       this.onDisplaySearch({ term: payload.id }, false, true);
+    },
+    onConnectivityItemClose: function () {
+      EventBus.emit('connectivity-item-close');
     },
     /**
      * Callback when an action is performed (open new dialogs).
@@ -307,7 +311,7 @@ export default {
      * @arg featureIds
      */
     onShowConnectivity: function (featureIds) {
-      if (featureIds.length) {        
+      if (featureIds.length) {
         const splitFlowState = this.splitFlowStore.getState();
         const activeView = splitFlowState?.activeView || '';
         // offset sidebar only on singlepanel and 2horpanel views

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -58,6 +58,18 @@ export default {
       this.startHelp();
     });
 
+    EventBus.on('connectivity-item-close', () => {
+      if (this.multiflatmapRef) {
+        const currentFlatmap = this.multiflatmapRef.getCurrentFlatmap();
+        if (currentFlatmap) {
+          currentFlatmap.closeTooltip();
+        }
+      }
+      if (this.flatmapRef) {
+        this.flatmapRef.closeTooltip();
+      }
+    });
+
     this.multiflatmapRef = this.$refs.multiflatmap;
     this.flatmapRef = this.$refs.flatmap;
     this.scaffoldRef = this.$refs.scaffold;


### PR DESCRIPTION
The connectivity explorer item close event is emitted in this [PR](https://github.com/ABI-Software/map-sidebar/pull/142).