### PR TITLE
Add missing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@abi-software/svg-sprite": "^1.0.1",
     "@element-plus/icons-vue": "^2.3.1",
     "@vitejs/plugin-vue": "^4.6.2",
+    "unplugin-vue-components": "^0.26.0",
     "css-element-queries": "^1.2.3",
     "element-plus": "2.8.4",
     "marked": "^4.3.0",


### PR DESCRIPTION
This `unplugin-vue-components` is used in `vite.config` but is missing in `package.json`. The app is working because it is included in other dependencies.