### PR TITLE
Replace pathways query with mapImp.pathways

### DIFF
--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -565,6 +565,7 @@ export default {
       flatmapQueries.initialise(this.flatmapAPI);
       const knowledge = await loadAndStoreKnowledge(flatmapImp, flatmapQueries);
       const uuid = flatmapImp.uuid;
+      const pathways = flatmapImp.pathways;
 
       if (!this.connectivityKnowledge[sckanVersion]) {
         this.connectivityKnowledge[sckanVersion] = knowledge
@@ -575,8 +576,7 @@ export default {
       }
 
       if (!this.connectivityKnowledge[uuid]) {
-        const mapPathsData = await flatmapQueries.queryMapPaths(uuid);
-        const pathsFromMap = mapPathsData ? mapPathsData.paths : {};
+        const pathsFromMap = pathways ? pathways.paths : {};
 
         this.connectivityKnowledge[uuid] = this.connectivityKnowledge[sckanVersion]
           .filter((item) => item.id in pathsFromMap);


### PR DESCRIPTION
The `queryMapPaths` method is removed in https://github.com/ABI-Software/flatmapvuer/pull/268, and `mapImp.pathways` is used to get data.