### PR TITLE
Fix connectivity data undefined while map is loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -427,7 +427,6 @@ export default {
             };
             if (anatomy) {
               currentEntry.organ = anatomy;
-              this.$refs.map.displaySearchFromQuery = anatomy;
             }
             this.$refs.map.setCurrentEntry(currentEntry);
           })

--- a/src/App.vue
+++ b/src/App.vue
@@ -382,6 +382,7 @@ export default {
         this.uuid = this.$route.query.id;
         const type = this.$route.query.type;
         const taxo = this.$route.query.taxo || this.$route.query.taxon;
+        const anatomy = this.$route.query.anatomy || this.$route.query.uberonid;
         const dataset_id = this.$route.query.dataset_id;
         const dataset_version = this.$route.query.dataset_version;
         const file_path = this.$route.query.file_path;
@@ -420,12 +421,15 @@ export default {
           // Load AC map with different species
           this.startingMap = "AC";
           this.$nextTick(() => {
-            this.$refs.map.setCurrentEntry(
-              {
-                type: "MultiFlatmap",
-                taxo: taxo,
-              }
-            );
+            const currentEntry = {
+              type: "MultiFlatmap",
+              taxo: taxo,
+            };
+            if (anatomy) {
+              currentEntry.organ = anatomy;
+              this.$refs.map.displaySearchFromQuery = anatomy;
+            }
+            this.$refs.map.setCurrentEntry(currentEntry);
           })
         } else if (type === 'fc') {
           // Load FC map

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -134,6 +134,7 @@ export default {
     return {
       isReady: false,
       initialState: undefined,
+      displaySearchFromQuery: '',
     }
   },
   methods: {
@@ -415,6 +416,12 @@ export default {
       this.initialState = await initialState(this.startingMap, this.options.sparcApi);
     }
     EventBus.on("mapLoaded", (map) => {
+      // Check if there is a search term to display
+      if (this.displaySearchFromQuery) {
+        setTimeout(() => {
+          this.$refs.flow.onDisplaySearch({term: this.displaySearchFromQuery});
+        });
+      }
       /**
        * This event emit when the map is loaded.
        */

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -423,6 +423,7 @@ export default {
       if (this.displaySearchFromQuery) {
         setTimeout(() => {
           this.$refs.flow.onDisplaySearch({term: this.displaySearchFromQuery});
+          this.displaySearchFromQuery = ''; // Clear after using it from first load
         });
       }
       /**

--- a/src/components/MapContent.vue
+++ b/src/components/MapContent.vue
@@ -312,6 +312,9 @@ export default {
                       //is current
                       if (state.uuid) entry.state.state.entry = state.taxo;
                     }
+                    if (state.organ) {
+                      this.displaySearchFromQuery = state.organ;
+                    }
                     this.$refs.flow.setState(currentState);
                     //Do not create a new entry, instead set the multiflatmap viewer
                     //to the primary slot

--- a/src/components/SplitDialog.vue
+++ b/src/components/SplitDialog.vue
@@ -203,8 +203,9 @@ export default {
         const uniqueFilters = this.connectivitiesStore.getUniqueFilterOptionsByKeys;
         EventBus.emit("connectivity-filter-options", uniqueFilters);
       } else {
+        const connectivityData = this.connectivitiesStore.globalConnectivities[sckanVersion] || [];
         EventBus.emit("connectivity-knowledge", {
-            data: this.connectivitiesStore.globalConnectivities[sckanVersion],
+            data: connectivityData,
             highlight: [],
             processed: false,
         });

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -103,8 +103,10 @@ export default {
       this.$emit("flatmap-provenance-ready", provClone);
       this.flatmapReadyForMarkerUpdates(flatmap);
       this.updateViewerSettings();
-      this.loadConnectivityExplorerConfig(flatmap);
-      EventBus.emit("mapLoaded", flatmap);
+      // Wait for flatmap's connectivity to load before emitting mapLoaded
+      this.loadConnectivityExplorerConfig(flatmap).then(() => {
+        EventBus.emit("mapLoaded", flatmap);
+      });
     },
     onPathwaySelectionChanged: function (data) {
       const { label, property, checked, selectionsTitle } = data;

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -228,8 +228,10 @@ export default {
         this.flatmapMarkerUpdate(flatmapImp);
         this.updateProvCard();
         this.updateViewerSettings();
-        this.loadConnectivityExplorerConfig(flatmap);
-        EventBus.emit("mapLoaded", flatmap);
+        // Wait for flatmap's connectivity to load before emitting mapLoaded
+        this.loadConnectivityExplorerConfig(flatmap).then(() => {
+          EventBus.emit("mapLoaded", flatmap);
+        });
       }
     },
     getFlatmapImp: function () {


### PR DESCRIPTION
When loading the map with `uberonid`, the feature should be highlighted after the map is loaded. However, because the flatmap's connectivity data is loaded after the map is loaded, it overrides the highlights. 
In this fix, the `mapLoaded` event will wait for connectivity data to be loaded, and the search term from `uberonid` will be applied after the `mapLoaded` event. After the search highlight is used, it will be cleared so that the user's interaction with the new map loaded from the species will not trigger this highlight.

- Heart test: https://mapintegratedvuer-mapcore-754fcb3bf891.herokuapp.com/#/?type=ac&taxo=NCBITaxon:10114&uberonid=UBERON:0000948
- Keast 2 test: https://mapintegratedvuer-mapcore-754fcb3bf891.herokuapp.com/#/?type=ac&taxo=NCBITaxon:10114&uberonid=ilxtr:neuron-type-keast-2