### PR TITLE
Update flatmapvuer and map-sidebar.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.14.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmapvuer": "1.12.0-beta.0",
-        "@abi-software/map-side-bar": "2.11.0",
+        "@abi-software/flatmapvuer": "1.12.0-beta.1",
+        "@abi-software/map-side-bar": "2.11.2",
         "@abi-software/map-utilities": "1.7.6",
         "@abi-software/plotvuer": "1.0.5",
         "@abi-software/scaffoldvuer": "1.13.0-beta.0",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@abi-software/flatmapvuer": {
-      "version": "1.12.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.12.0-beta.0.tgz",
-      "integrity": "sha512-9kSLGAulQyUip8pJMsiG5NNnc4YWtVKF7Yzf9lH5pZWHeYCJ8dAESCIuY8TOuRsKO1uBsWEn7Vq1mzooRqEnRg==",
+      "version": "1.12.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmapvuer/-/flatmapvuer-1.12.0-beta.1.tgz",
+      "integrity": "sha512-qIGVjT2YWJr8frEJ8CKCwn70395MskYnVWdAMck7xbAoRBPaCOdaLPNdPkmf9oD2qotQV9DSY5BhZmXg9nBShA==",
       "dependencies": {
         "@abi-software/map-utilities": "^1.7.6",
         "@abi-software/sparc-annotation": "0.3.2",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@abi-software/map-side-bar": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-2.11.0.tgz",
-      "integrity": "sha512-DRFgCpJdtaAmvps5YLLJXg9eaLFfSfzAQ0oWmckvLHst4eJObHTBZBDbeLqgJ58McNJOvCheVv+2S/vne7ra5g==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@abi-software/map-side-bar/-/map-side-bar-2.11.2.tgz",
+      "integrity": "sha512-3Z/f8knteJfKqRktXVpVv+Y6Wa9SVNXOHiPGRfd/L174RYuWo4OX/GJWhN5e/fTYjSA++6mbNEDylBaN790oLA==",
       "dependencies": {
         "@abi-software/gallery": "^1.2.0",
         "@abi-software/map-utilities": "1.7.6",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "*.js"
   ],
   "dependencies": {
-    "@abi-software/flatmapvuer": "1.12.0-beta.0",
-    "@abi-software/map-side-bar": "2.11.0",
+    "@abi-software/flatmapvuer": "1.12.0-beta.1",
+    "@abi-software/map-side-bar": "2.11.2",
     "@abi-software/map-utilities": "1.7.6",
     "@abi-software/plotvuer": "1.0.5",
     "@abi-software/scaffoldvuer": "1.13.0-beta.0",


### PR DESCRIPTION
Update flatmapvuer and map-sidebar which should address the following two issues:

- Alert filter does not work on connectivity explorer
- Minimap background colour does not change in flatmapvuer