### PR TITLE
Fix an issue with connectivity when opening wholebody scaffold from dataset

### DIFF
--- a/src/components/viewers/Scaffold.vue
+++ b/src/components/viewers/Scaffold.vue
@@ -36,7 +36,7 @@
       :showOpenMapButton="showOpenMapButton"
       :usageConfig="{
         showTubeLinesControls: false,
-        tubeLines: (entry.discoverId === '307')
+        tubeLines: (entry.discoverId === '307' || entry.discoverId === 307)
       }"
     />
 
@@ -322,7 +322,7 @@ export default {
   },
   computed: {
     warningMessage: function() {
-      if (this.entry.isBodyScaffold) {
+      if ((this.entry.discoverId === '307' || this.entry.discoverId === 307)) {
         return "This map displays the anatomical location and connectivity of nerves, through which the neuron populations from the ApiNATOMY models available in SCKAN can be routed.";
       } else {
         return "Under active development";


### PR DESCRIPTION
Make sure whole body scaffold opening from dataset get the same functionality as opening the whole body scaffold from the banner.