### PR TITLE
Allow pop up to be updated when there is a selected primitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@abi-software/map-side-bar": "2.11.2",
         "@abi-software/map-utilities": "1.7.6",
         "@abi-software/plotvuer": "1.0.5",
-        "@abi-software/scaffoldvuer": "1.13.0-beta.0",
+        "@abi-software/scaffoldvuer": "^1.13.0-beta.2",
         "@abi-software/simulationvuer": "2.0.17",
         "@abi-software/sparc-annotation": "0.3.2",
         "@abi-software/svg-sprite": "1.0.3",
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@abi-software/scaffoldvuer": {
-      "version": "1.13.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@abi-software/scaffoldvuer/-/scaffoldvuer-1.13.0-beta.0.tgz",
-      "integrity": "sha512-RhG9JCXU0J0O9EUOYRMtZWJ9iQoA88bj/mubgQxHZZ6eXBONbBV/PqpyeFppO59nJLWDDP3MZHIslN3+1BjllQ==",
+      "version": "1.13.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@abi-software/scaffoldvuer/-/scaffoldvuer-1.13.0-beta.2.tgz",
+      "integrity": "sha512-PQKohtjNKzI3axgZOjzYnRmTehs8lu7th+xMamkVLVt5qdkZmWRY9d94AYDAnq9ko1sevJMs3vmyL6ZEVREQuA==",
       "dependencies": {
         "@abi-software/map-utilities": "^1.7.6",
         "@abi-software/sparc-annotation": "^0.3.2",
@@ -189,7 +189,7 @@
         "unplugin-vue-components": "^0.26.0",
         "vue": "^3.4.21",
         "vue-router": "^4.2.5",
-        "zincjs": "^1.16.0"
+        "zincjs": "^1.16.1"
       }
     },
     "node_modules/@abi-software/scaffoldvuer/node_modules/@abi-software/svg-sprite": {
@@ -14542,9 +14542,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -15835,9 +15835,9 @@
       }
     },
     "node_modules/zincjs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/zincjs/-/zincjs-1.16.0.tgz",
-      "integrity": "sha512-7QjuMEOT03Rwml/GuYGFjLX4mOCasnLDbwrx+UANasFKLvwbIbbD+5t3IV+0Pj5vzezb0qmV3x1Opze48+7JrA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/zincjs/-/zincjs-1.16.1.tgz",
+      "integrity": "sha512-HqLRD+HN3qayn+xyMVDRyjM8p2mzSOdtPc8WFRRjURHTiGpAFsV1WIsBD4r1/6qi+il/uDxkDKxxVekPpiu6OA==",
       "dependencies": {
         "css-element-queries": "^1.2.2",
         "lodash": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@abi-software/map-side-bar": "2.11.2",
     "@abi-software/map-utilities": "1.7.6",
     "@abi-software/plotvuer": "1.0.5",
-    "@abi-software/scaffoldvuer": "1.13.0-beta.0",
+    "@abi-software/scaffoldvuer": "^1.13.0-beta.2",
     "@abi-software/simulationvuer": "2.0.17",
     "@abi-software/sparc-annotation": "0.3.2",
     "@abi-software/svg-sprite": "1.0.3",


### PR DESCRIPTION
Allow pop up to be updated when there is a selected primitive. This behaviour is consistent with the interaction in flatmapvuer.

Addressing the issue here - https://github.com/orgs/ABI-Software/projects/1/views/1?pane=issue&itemId=129290430&issue=ABI-Software%7Cmapcore-issues%7C11