### PR TITLE
Provide a workaround with bug found on source changed.

### DIFF
--- a/src/components/ContentVuer.vue
+++ b/src/components/ContentVuer.vue
@@ -126,8 +126,8 @@ export default {
     onConnectivityItemClose: function() {
       this.$refs.viewer?.onConnectivityItemClose();
     },
-    onConnectivitySourceChange: function(payload) {
-      this.$refs.viewer?.changeConnectivitySource(payload);
+    onConnectivitySourceChange: function(payload, ongoingSource) {
+      this.$refs.viewer?.changeConnectivitySource(payload, ongoingSource);
     },
     onFlatmapMarkerUpdate: function() {
       this.$refs.viewer?.flatmapMarkerUpdate();

--- a/src/components/SplitDialog.vue
+++ b/src/components/SplitDialog.vue
@@ -572,8 +572,14 @@ export default {
     });
     EventBus.on('connectivity-source-change', (payload) => {
       const contents = this.getActiveContents();
+      //Use ongoingSource array to make sure, the knowledge
+      //from each source is only loaded once.
+      //TODO: This can be improved with using just one viewer to give us
+      //the new knowlegdge with the species/sources specified which
+      //will require some UI changes on the sidebar
+      const ongoingSources = []
       contents.forEach((content) => {
-        content.onConnectivitySourceChange(payload);
+        content.onConnectivitySourceChange(payload, ongoingSources);
       });
     });
     EventBus.on('show-connectivity', (payload) => {

--- a/src/components/viewers/Flatmap.vue
+++ b/src/components/viewers/Flatmap.vue
@@ -174,10 +174,14 @@ export default {
         }
       }
     },
-    changeConnectivitySource: function (payload) {
+    changeConnectivitySource: function (payload, ongoingSource) {
       if (this?.alive && this.flatmapReady) {
-        const flatmap = this.$refs.multiflatmap.getCurrentFlatmap();
-        flatmap.changeConnectivitySource(payload);
+        const flatmap = this.$refs.flatmap;
+        const flatmapUUID = flatmap.mapImp.mapMetadata.uuid;
+        if (!ongoingSource.includes(flatmapUUID)) {
+          ongoingSource.push(flatmapUUID);
+          flatmap.changeConnectivitySource(payload);
+        }
       }
     },
     zoomToFeatures: function(info, forceSelect) {

--- a/src/components/viewers/MultiFlatmap.vue
+++ b/src/components/viewers/MultiFlatmap.vue
@@ -359,10 +359,14 @@ export default {
         }
       }
     },
-    changeConnectivitySource: function (payload) {
+    changeConnectivitySource: function (payload, ongoingSource) {
       if (this?.alive && this.flatmapReady) {
         const flatmap = this.$refs.multiflatmap.getCurrentFlatmap();
-        flatmap.changeConnectivitySource(payload);
+        const flatmapUUID = flatmap.mapImp.mapMetadata.uuid;
+        if (!ongoingSource.includes(flatmapUUID)) {
+          ongoingSource.push(flatmapUUID);
+          flatmap.changeConnectivitySource(payload);
+        }
       }
     },
     updateViewerSettings: function () {

--- a/src/mixins/ContentMixin.js
+++ b/src/mixins/ContentMixin.js
@@ -802,16 +802,20 @@ export default {
         EventBus.emit('connectivity-info-open', this.tooltipEntry);
       }
     },
-    changeConnectivitySource: async function (payload) {
+    changeConnectivitySource: async function (payload, ongoingSource) {
       const { entry, connectivitySource } = payload;
-      await this.flatmapQueries.queryForConnectivityNew(this.flatmapService.mapImp, entry.featureId[0], connectivitySource);
-      this.tooltipEntry = this.tooltipEntry.map((tooltip) => {
-        if (tooltip.featureId[0] === entry.featureId[0]) {
-          return this.flatmapQueries.updateTooltipData(tooltip);
-        }
-        return tooltip;
-      })
-      EventBus.emit('connectivity-info-open', this.tooltipEntry);
+      const flatmapUUID = this?.flatmapService?.mapImp?.mapMetadata.uuid;
+      if (!ongoingSource.includes(flatmapUUID)) {
+        ongoingSource.push(flatmapUUID);
+        await this.flatmapQueries.queryForConnectivityNew(this.flatmapService.mapImp, entry.featureId[0], connectivitySource);
+        this.tooltipEntry = this.tooltipEntry.map((tooltip) => {
+          if (tooltip.featureId[0] === entry.featureId[0]) {
+            return this.flatmapQueries.updateTooltipData(tooltip);
+          }
+          return tooltip;
+        })
+        EventBus.emit('connectivity-info-open', this.tooltipEntry);
+      }
     },
     trackEvent: function (data) {
       Tagging.sendEvent(data);


### PR DESCRIPTION
Map-sidebar will be reset to display list of neuron populations after switching between Map/SCKAN knowledge when the map-viewer has multiple of the same species on display.

I have made some changes to make sure only one of the viewers in this case will process the required changes.